### PR TITLE
Update collection for certification

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.13.0"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.13.0"
+requires_ansible: ">=2.14.0"

--- a/plugins/httpapi/om.py
+++ b/plugins/httpapi/om.py
@@ -7,6 +7,7 @@ import json
 from ansible.module_utils.connection import ConnectionError
 from ansible.plugins.httpapi import HttpApiBase
 
+
 def handle_response(response):
     if response:
         handled_response = json.loads(response.getvalue())

--- a/plugins/module_utils/network/om/config/ports/ports.py
+++ b/plugins/module_utils/network/om/config/ports/ports.py
@@ -30,7 +30,6 @@ from ansible.module_utils.connection import ConnectionError
 
 from ansible_collections.opengear.om.plugins.module_utils.network.om.utils.utils import (
     command_builder,
-    find_instance_id,
     is_subset,
 )
 

--- a/tests/unit/modules/network/om/test_om_users.py
+++ b/tests/unit/modules/network/om/test_om_users.py
@@ -81,16 +81,16 @@ class TestOmUsersModule(TestOmModule):
         )
 
         commands = [
-                dict(path='users/users-1',
-                     data=dict(user=dict(username="user1-modified", description="This user was changed", enabled=False,
-                               no_password=True, ssh_password_enabled=True, password=None,
-                               hashed_password="$5$vqpQsIj./5/2OOBo$tTUYAJaEqbZYf4aipKicPF5bpkkGSEqtBy3t4dylp0/",
-                               groups=["g2", "g1"])),
-                     method='PUT'),
-                dict(path='users/',
-                     data=dict(user=dict(username="user3", description="This user was added", enabled=True, no_password=True,
-                               groups=["g1"])),
-                     method='POST')]
+            dict(path='users/users-1',
+                data=dict(user=dict(username="user1-modified", description="This user was changed", enabled=False,
+                            no_password=True, ssh_password_enabled=True, password=None,
+                            hashed_password="$5$vqpQsIj./5/2OOBo$tTUYAJaEqbZYf4aipKicPF5bpkkGSEqtBy3t4dylp0/",
+                            groups=["g2", "g1"])),
+                    method='PUT'),
+            dict(path='users/',
+                data=dict(user=dict(username="user3", description="This user was added", enabled=True, no_password=True,
+                            groups=["g1"])),
+                method='POST')]
         self.execute_module(changed=True, commands=commands)
 
     def test_om_users_merged_idempotent(self):


### PR DESCRIPTION
Apologies on the delay for this. 

**Meta Directory**

Used to house mainly the runtime.yml file which can house a bunch of things like redirects etc if you all need to rename/deprecate modules etc. This change explicitly states what version of ansible-core the collection supports. given 2.9 is EOL and will be EOL downstream soon, I dropped 2.13 in but I can change this to whatever supported version you all wish to start with and want to test against. This is displayed to users via the collection page so it can be used a support statement. 

**Python file changes** 

I ran the sanity suite over the collection from the latest core release, 2.15.2, and saw some errors. I started addressing some of them but then released as I got to the unused imports, it was probably best for you all to do that given that I only CI lint outputs and I don't necessarily know the code base well and what it is interacting with at all. 

httpapi and the test fix were all pep8 violations and then you can start to see the unused import removals where I stopped. 

The primary offender was just unused imports from pylint around `re` not being used. Happy to fix those here or let you all deal with them.

**Running Sanity** 

Can be done in CLI or easily from your dev environment, the collection will need to be built and installed, then just run `ansible-test sanity` at the top level of the collection install location (default is ~/.ansible/collections/ansible_collections/opengear/om). Optionally, if docker is installed, you can pass the --docker argument and ansible-test will pull down and run the sanity suite against all supported core python versions (you don't have to support them, they can be ignored and suppressed with a file). 