### PR TITLE
Remove hardcoded path to structure.json

### DIFF
--- a/plugins/module_utils/network/om/utils/utils.py
+++ b/plugins/module_utils/network/om/utils/utils.py
@@ -9,12 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import json
+import json, os
 
 
 def get_restapi_body_structure():
-    with open('/home/avankat/Documents/automated-device-config/opengear.om/'
-              'plugins/module_utils/network/om/utils/structure.json') as file:
+    with open(os.path.dirname(__file__) + '/structure.json') as file:
         return json.load(file)
 
 


### PR DESCRIPTION
Hardcoded path to `structure.json` breaks running this on other machines. Probably a much better way to do this but seem to work locally 

To fix issue https://github.com/opengear/opengear.om/issues/3 and https://github.com/opengear/opengear.om/issues/9

