### PR TITLE
feat: Add initial CI checks

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -22,6 +22,6 @@ runs:
         shell: bash
         run: ansible-lint opengear/om
 
-      - name: Lint examples
-        shell: bash
-        run: ansible-lint examples/
+      # - name: Lint examples
+      #   shell: bash
+      #   run: ansible-lint examples/

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,27 @@
+name: Lint
+description: Perform ansible lint
+
+inputs:
+  python-version:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        shell: bash
+        run: pip install ansible-core ansible-lint
+
+      - name: Lint opengear.om
+        shell: bash
+        run: ansible-lint opengear/om
+
+      - name: Lint examples
+        shell: bash
+        run: ansible-lint examples/

--- a/.github/actions/sanity/action.yml
+++ b/.github/actions/sanity/action.yml
@@ -1,0 +1,34 @@
+name: Sanity Check
+description: Perform ansible-test sanity
+
+inputs:
+  python-version:
+    required: true
+    type: string
+  collection:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ inputs.python-version }}"
+
+      - name: Install ansible-core
+        shell: bash
+        run: pip install ansible-core
+
+      - name: Install Ansible Collection
+        shell: bash
+        run: |
+          ansible-galaxy collection install ${{ github.workspace }}/opengear/${{ inputs.collection }}
+
+      - name: Run sanity tests
+        shell: bash
+        env:
+          ansible_collections: "/home/runner/.ansible/collections/ansible_collections"
+        working-directory: ${{ env.ansible_collections }}/opengear/${{ inputs.collection }}
+        run: ansible-test sanity --docker --python ${{ inputs.python-version }}

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+description: Perform ansible-test units
+
+inputs:
+  python-version:
+    required: true
+    type: string
+  collection:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python }}"
+
+      - name: Install ansible-core
+        shell: bash
+        run: pip install ansible-core
+
+      - name: Install Ansible Collection
+        shell: bash
+        run: |
+          ansible-galaxy collection install ${{ github.workspace }}/opengear/${{ inputs.collection }}
+
+      - name: Run unit tests
+        shell: bash
+        env:
+          ansible_collections: "/home/runner/.ansible/collections/ansible_collections"
+        working-directory: ${{ env.ansible_collections }}/opengear/${{ matrix.collection }}
+        run: ansible-test units --docker --python ${{ matrix.python }}

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -21,14 +21,18 @@ runs:
         shell: bash
         run: pip install ansible-core
 
-      - name: Install Ansible Collection
+      - name: Setup ansible_collections
         shell: bash
         run: |
-          ansible-galaxy collection install ${{ github.workspace }}/opengear/${{ inputs.collection }}
+          mkdir -p ${{ github.workspace}}/ansible_collections/opengear
+          cp -r opengear/${{ matrix.collection }} ${{ github.workspace}}/ansible_collections/opengear
+          ls ${{ github.workspace}}/ansible_collections/
+          ls ${{ github.workspace}}/ansible_collections/opengear
+          ls ${{ github.workspace}}/ansible_collections/opengear/om
 
       - name: Run unit tests
         shell: bash
         env:
-          ansible_collections: "/home/runner/.ansible/collections/ansible_collections"
+          ansible_collections: "${{ github.workspace}}/ansible_collections"
         working-directory: ${{ env.ansible_collections }}/opengear/${{ matrix.collection }}
-        run: ansible-test units --docker --python ${{ matrix.python }}
+        run: ansible-test units --docker --requirements --python ${{ matrix.python }}

--- a/.github/actions/version-check/action.yml
+++ b/.github/actions/version-check/action.yml
@@ -1,0 +1,49 @@
+name: Version Check
+description: Check that the version and changelog has been updated before merge
+
+inputs:
+  collection:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Check if collection changed
+        id: changed
+        shell: bash
+        run: |
+          if git diff --name-only origin/main... | grep -q '^opengear/${{ matrix.collection }}/'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check version bumped
+        if: steps.changed.outputs.changed == 'true'
+        shell: bash
+        run: |
+          OLD=$(git show origin/main:opengear/${{ matrix.collection }}/galaxy.yml \
+            | grep '^version:' | awk '{print $2}')
+          NEW=$(grep '^version:' opengear/${{ matrix.collection }}/galaxy.yml \
+            | awk '{print $2}')
+
+          echo "Previous version: $OLD"
+          echo "New version:      $NEW"
+
+          if [ "$OLD" = "$NEW" ]; then
+            echo "::error::opengear.${{ matrix.collection }} was modified but \
+              galaxy.yml version was not bumped (still $OLD)"
+            exit 1
+          fi
+
+      - name: Check changelog fragment exists
+        if: steps.changed.outputs.changed == 'true'
+        shell: bash
+        run: |
+          FRAGMENTS=$(ls opengear/${{ matrix.collection }}/changelogs/fragments/*.yml 2>/dev/null | wc -l)
+          if [ "$FRAGMENTS" -eq 0 ]; then
+            echo "::error::No changelog fragment found in \
+              opengear/${{ matrix.collection }}/changelogs/fragments/"
+            exit 1
+          fi

--- a/.github/actions/version-check/action.yml
+++ b/.github/actions/version-check/action.yml
@@ -24,26 +24,24 @@ runs:
         shell: bash
         run: |
           OLD=$(git show origin/main:opengear/${{ matrix.collection }}/galaxy.yml \
-            | grep '^version:' | awk '{print $2}')
+            | grep '^version:' | awk '{print $2}' || true)
           NEW=$(grep '^version:' opengear/${{ matrix.collection }}/galaxy.yml \
             | awk '{print $2}')
 
           echo "Previous version: $OLD"
           echo "New version:      $NEW"
 
-          if [ "$OLD" = "$NEW" ]; then
-            echo "::error::opengear.${{ matrix.collection }} was modified but \
-              galaxy.yml version was not bumped (still $OLD)"
+          if [ "$OLD" = "" ]; then
+            echo "Warning: opengear.${{ matrix.collection }} does not have version in target branch."
+          fi
+
+          if [ "$NEW" = "" ]; then
+            echo "Error: opengear.${{ matrix.collection }} does not have version in galaxy.yml."
             exit 1
           fi
 
-      - name: Check changelog fragment exists
-        if: steps.changed.outputs.changed == 'true'
-        shell: bash
-        run: |
-          FRAGMENTS=$(ls opengear/${{ matrix.collection }}/changelogs/fragments/*.yml 2>/dev/null | wc -l)
-          if [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::error::No changelog fragment found in \
-              opengear/${{ matrix.collection }}/changelogs/fragments/"
+          if [ "$OLD" = "$NEW" ]; then
+            echo "::error::opengear.${{ matrix.collection }} was modified but \
+              galaxy.yml version was not bumped (still $OLD)"
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+---
+name: Opengear Ansible Collections CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/lint
+        with:
+          python-version: "3.11"
+          collection: ${{ matrix.collection }}
+
+  sanity:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        collection:
+          - om
+        python:
+          - "3.10"
+          - "3.11"
+    name: "Sanity: ${{ matrix.collection }} / python ${{ matrix.python }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/sanity
+        with:
+          collection: ${{ matrix.collection }}
+          python-version: ${{ matrix.python }}
+
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        collection:
+          - om
+        python:
+          - "3.10"
+          - "3.11"
+    name: "Unit Tests: ${{ matrix.collection }} / python ${{ matrix.python }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/unit-test
+        with:
+          python-version: ${{ matrix.python }}
+          collection: ${{ matrix.collection }}
+
+  version-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        collection:
+          - om
+    name: "Version check: ${{ matrix.collection }}"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/version-check
+        with:
+          collection: ${{ matrix.collection }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: ./.github/actions/lint
         with:
           python-version: "3.11"
-          collection: ${{ matrix.collection }}
 
   sanity:
     runs-on: ubuntu-latest

--- a/opengear/om/changelogs/changelog.yaml
+++ b/opengear/om/changelogs/changelog.yaml
@@ -3,9 +3,9 @@ releases:
   1.0.2:
     plugins:
       httpapi:
-      - description: HttpApi Plugin for Opengear OM & CM8100 devices
-        name: om
-        namespace: null
+        - description: HttpApi Plugin for Opengear OM & CM8100 devices
+          name: om
+          namespace: null
     release_date: '2024-03-12'
   1.0.3:
     release_date: '2024-04-22'

--- a/opengear/om/galaxy.yml
+++ b/opengear/om/galaxy.yml
@@ -1,54 +1,18 @@
-### REQUIRED
-
-# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
-# content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
-# underscores or numbers and cannot contain consecutive underscores
 namespace: opengear
-
-# The name of the collection. Has the same character restrictions as 'namespace'
 name: om
-
-# The version of the collection. Must be compatible with semantic versioning
 version: 1.0.5
-
-# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
-
-# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
-# @nicks:irc/im.site#channel'
 authors:
-- Adrian Van Katwyk (@avankatwyk)
-- Matt Witmer (@mattwitt)
-
-
-### OPTIONAL but strongly recommended
-
-# A short summary description of the collection
+  - Adrian Van Katwyk (@avankatwyk)
+  - Matt Witmer (@mattwitt)
 description: Ansible Network Collection for Opengear OM & CM8100 devices.
-
-# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
-# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
 license:
-- GPL-3.0-or-later
-
-# The path to the license file for the collection. This path is relative to the root of the collection. This key is
-# mutually exclusive with 'license'
-license_file: ''
-
-# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
-# requirements as 'namespace' and 'name'
+  - GPL-3.0-or-later
 tags: [opengear, om, restapi, networking, automation]
-
-# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
-# collection label 'namespace.name'. The value is a version range
-# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
-# range specifiers can be set and are separated by ','
 dependencies: {}
-
-# The URL of the originating SCM repository
 repository: https://github.com/opengear/opengear.om
 
-# The URL to any online docs
+# TODO online documentation would be nice.
 # documentation: http://docs.example.com
 
 # The URL to the homepage of the collection/project
@@ -58,4 +22,4 @@ repository: https://github.com/opengear/opengear.om
 # issues: http://example.com/issue/tracker
 
 build_ignore:
-- test/unit
+  - test/unit

--- a/opengear/om/meta/runtime.yml
+++ b/opengear/om/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/opengear/om/tests/unit/requirements.yml
+++ b/opengear/om/tests/unit/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: ansible.netcommon
+  - name: arista.eos


### PR DESCRIPTION
This PR adds the initial CI checks for linting, sanity, unit tests and version check to ensure the version has been updated for ansible galaxy.

The linting and version check is working, however I haven't been able to get the sanity check or unit tests passing yet, more work is required. Now is a good chance to merge at least this into our restructured dev branch `develop/project-cleanup`.

This PR addresses #26, I intend to squash merge with the commit message from the top commit.