### PR TITLE
Feature/integration tests

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -1,0 +1,58 @@
+name: Integration Tests
+description: Perform ansible-test network-integration which tests module against real devices
+
+inputs:
+  python-version:
+    required: true
+    type: string
+  collection:
+    required: true
+    type: string
+  inventory-file:
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ inputs.python-version }}"
+
+      - name: Create and activate clean virtual environment
+        shell: bash
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+
+      - name: Install ansible-core
+        shell: bash
+        run: pip install ansible-core
+
+      - name: Clean up previous Ansible collections
+        shell: bash
+        run: |
+          rm -rf ~/.ansible/collections
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          ansible-galaxy collection install ansible.netcommon:">=8.1.0" -p ~/.ansible/collections/
+
+      - name: Setup Opengear ansible_collections
+        shell: bash
+        run: |
+          mkdir -p ~/.ansible/collections/ansible_collections/opengear
+          cp -r opengear/${{ inputs.collection }} ~/.ansible/collections/ansible_collections/opengear
+          # cp ${{ inputs.inventory-file }} ~/.ansible/collections/ansible_collections/opengear/${{ inputs.collection }}/tests/integration/${{ inputs.inventory-file }}
+          find ~/.ansible/collections/ansible_collections/opengear/${{ inputs.collection }}/tests -type d
+
+      - name: Run integration tests
+        shell: bash
+        run: |
+          cd ~/.ansible/collections/ansible_collections/opengear/${{ inputs.collection }}
+          ansible-test network-integration \
+            --python ${{ inputs.python-version }} \
+            --inventory ${{ github.workspace }}/${{ inputs.inventory-file }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Skip version check
+        if: "!startsWith(github.ref, 'refs/heads/release/')"
+        run: echo "Version check skipped - only runs on release branches"
+
       - name: Run version check
         uses: ./.github/actions/version-check
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
         with:
           collection: ${{ matrix.collection }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,13 @@ on:
       - main
       - develop/**
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_integration:
+        description: 'Run integration tests'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   lint:
@@ -72,3 +79,45 @@ jobs:
         uses: ./.github/actions/version-check
         with:
           collection: ${{ matrix.collection }}
+
+  integration-test:
+    name: Integration Tests
+    needs: [lint, sanity, unit-test]
+    runs-on: [self-hosted, ansible, integration-tests]
+    environment: integration-tests
+    # automatically run on main branch and release branches
+    # manual trigger with run_integration
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop/project-cleanup') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_integration)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build inventory
+        run: |
+          cat > inventory.networking << EOF
+          [opengear]
+          test-om ansible_host=${{ secrets.OM2200_DEVICE_HOST }} \
+                  ansible_user=${{ secrets.OM2200_DEVICE_USER }} \
+                  ansible_password=${{ secrets.OM2200_DEVICE_PASSWORD }}
+          [opengear:vars]
+          ansible_connection=httpapi
+          ansible_httpapi_use_ssl=true
+          ansible_httpapi_validate_certs=false
+          ansible_network_os=opengear.om.om
+          EOF
+
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          python-version: "3.11"
+          collection: "om"
+          inventory-file: inventory.networking
+
+      - name: Cleanup inventory
+        if: always()
+        shell: bash
+        run: rm -f inventory.networking

--- a/opengear/om/galaxy.yml
+++ b/opengear/om/galaxy.yml
@@ -8,7 +8,8 @@ description: Ansible Network Collection for Opengear OM & CM8100 devices.
 license:
   - GPL-3.0-or-later
 tags: [opengear, om, restapi, networking, automation]
-dependencies: {}
+dependencies:
+  "ansible.netcommon": ">=8.1.0"
 repository: https://github.com/opengear/opengear.om
 
 # TODO online documentation would be nice.
@@ -21,4 +22,5 @@ repository: https://github.com/opengear/opengear.om
 # issues: http://example.com/issue/tracker
 
 build_ignore:
-  - test/unit
+  - tests/unit
+  - tests/integration

--- a/opengear/om/plugins/module_utils/network/om/config/groups/groups.py
+++ b/opengear/om/plugins/module_utils/network/om/config/groups/groups.py
@@ -22,6 +22,7 @@ from ansible_collections.opengear.om.plugins.module_utils.network.om.utils.utils
     to_list,
     dict_diff,
     dict_merge,
+    is_subset,
     remove_empties,
 )
 from ansible_collections.opengear.om.plugins.module_utils.network.om.facts.facts import Facts
@@ -180,7 +181,7 @@ class Groups(ConfigBase):
             if group_id in id_group_map:
                 data = remove_empties(group)
                 data['id'] = group_id
-                if data == remove_empties(id_group_map[group_id]):
+                if is_subset(data, remove_empties(id_group_map[group_id])):
                     continue
             command = command_builder({'group': group}, 'groups/', group_id)
             if command:

--- a/opengear/om/plugins/module_utils/network/om/utils/utils.py
+++ b/opengear/om/plugins/module_utils/network/om/utils/utils.py
@@ -136,14 +136,14 @@ def dict_merge(base, other):
 
 
 def remove_empties(cfg_dict):
-    """Recursively remove keys with None, [], '', or {} values."""
+    """Recursively remove keys with None, '', or {} values. Empty lists are allowed."""
     result = {}
     for key, value in cfg_dict.items():
         if isinstance(value, dict):
             nested = remove_empties(value)
             if nested:
                 result[key] = nested
-        elif value not in (None, [], '', {}):
+        elif value not in (None, '', {}):
             result[key] = value
     return result
 

--- a/opengear/om/tests/integration/targets/om_facts/aliases
+++ b/opengear/om/tests/integration/targets/om_facts/aliases
@@ -1,0 +1,1 @@
+network/opengear

--- a/opengear/om/tests/integration/targets/om_facts/tasks/main.yml
+++ b/opengear/om/tests/integration/targets/om_facts/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# Integration tests for om_facts module
+# Verifies that gather_network_resources correctly dispatches to each facts class
+
+- name: Gather groups facts
+  opengear.om.om_facts:
+    gather_network_resources:
+      - groups
+  register: result
+
+- name: Assert groups were gathered
+  ansible.builtin.assert:
+    that:
+      - result.ansible_facts.ansible_network_resources.groups is defined
+      - result.ansible_facts.ansible_network_resources.groups | length > 0
+
+- name: Gather users facts
+  opengear.om.om_facts:
+    gather_network_resources:
+      - users
+  register: result
+
+- name: Assert users were gathered
+  ansible.builtin.assert:
+    that:
+      - result.ansible_facts.ansible_network_resources.users is defined
+      - result.ansible_facts.ansible_network_resources.users | length > 0
+
+- name: Gather multiple resources in one call
+  opengear.om.om_facts:
+    gather_network_resources:
+      - groups
+      - users
+  register: result
+
+- name: Assert both resources returned
+  ansible.builtin.assert:
+    that:
+      - result.ansible_facts.ansible_network_resources.groups is defined
+      - result.ansible_facts.ansible_network_resources.users is defined
+      - result.ansible_facts.ansible_network_resources.groups | length > 0
+      - result.ansible_facts.ansible_network_resources.users | length > 0

--- a/opengear/om/tests/integration/targets/om_groups/aliases
+++ b/opengear/om/tests/integration/targets/om_groups/aliases
@@ -1,0 +1,1 @@
+network/opengear

--- a/opengear/om/tests/integration/targets/om_groups/tasks/main.yml
+++ b/opengear/om/tests/integration/targets/om_groups/tasks/main.yml
@@ -1,0 +1,345 @@
+---
+# Integration tests for om_groups module
+# Assumes a factory reset device with default groups:
+#  - admin  (enabled: true,  access_rights: [admin])
+#  - netgrp (enabled: false, access_rights: [admin])
+
+# --- gathered ---
+- name: Gather groups from device
+  opengear.om.om_groups:
+    state: gathered
+  register: result
+
+- name: Assert gathered returns default groups
+  ansible.builtin.assert:
+    that:
+      - result.gathered | length == 2
+      - result.gathered | selectattr('groupname', 'equalto', 'admin') | list | length == 1
+      - (result.gathered | selectattr('groupname', 'equalto', 'admin') | first).enabled == true
+      - (result.gathered | selectattr('groupname', 'equalto', 'admin') | first).access_rights == ['admin']
+      - result.gathered | selectattr('groupname', 'equalto', 'netgrp') | list | length == 1
+      - (result.gathered | selectattr('groupname', 'equalto', 'netgrp') | first).enabled == false
+      - (result.gathered | selectattr('groupname', 'equalto', 'netgrp') | first).access_rights == ['admin']
+
+# --- merged: create ---
+- name: Test merged-create
+  block:
+    - name: Create a new group via merged
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            description: Created by Ansible integration test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+              - ports-2
+        state: merged
+      register: result
+
+    - name: Assert group was created
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Gather groups and verify new group exists
+      opengear.om.om_groups:
+        state: gathered
+      register: result
+
+    - name: Assert new group is present with correct config
+      ansible.builtin.assert:
+        that:
+          - result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | list | length == 1
+          - (result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | first).enabled == true
+          - (result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | first).access_rights == ['pmshell']
+          - (result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | first).ports == ['ports-1', 'ports-2']
+
+  always:
+    - name: Cleanup - delete ansible-test group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+
+# --- merged: update (add port) ---
+- name: Test merged-update
+  block:
+    - name: Setup - create group to update
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+              - ports-2
+        state: merged
+
+    - name: Merge additional port into group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            ports:
+              - ports-3
+        state: merged
+      register: result
+
+    - name: Assert group was changed
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Gather and verify ports were merged not replaced
+      opengear.om.om_groups:
+        state: gathered
+      register: result
+
+    - name: Assert all ports are present
+      ansible.builtin.assert:
+        that:
+          - (result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | first).ports | sort == ['ports-1', 'ports-2', 'ports-3'] | sort
+
+  always:
+    - name: Cleanup - delete ansible-test group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+
+# --- merged: idempotent ---
+- name: Test merged-idempotent
+  block:
+    - name: Setup - create group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports: []
+        state: merged
+
+    - name: Merge same config again
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports: []
+        state: merged
+      register: result
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+
+  always:
+    - name: Cleanup - delete ansible-test group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+
+# --- replaced ---
+- name: Test replaced
+  block:
+    - name: Setup - create group with multiple ports
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+              - ports-2
+              - ports-3
+        state: merged
+
+    - name: Replace group with fewer ports
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+            members: []
+        state: replaced
+      register: result
+
+    - name: Assert group was changed
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Gather and verify only specified ports remain
+      opengear.om.om_groups:
+        state: gathered
+      register: result
+
+    - name: Assert ports were replaced not merged
+      ansible.builtin.assert:
+        that:
+          - (result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | first).ports == ['ports-1']
+
+  always:
+    - name: Cleanup - delete ansible-test group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+
+# --- replaced: idempotent ---
+- name: Test replaced-idempotent
+  block:
+    - name: Setup - create group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+            members: []
+        state: merged
+
+    - name: Replace with same config
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports:
+              - ports-1
+            members: []
+        state: replaced
+      register: result
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+
+  always:
+    - name: Cleanup - delete ansible-test group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+
+# --- overridden ---
+- name: Test overridden
+  block:
+    - name: Setup - create extra group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports: []
+        state: merged
+
+    - name: Override with only default groups
+      opengear.om.om_groups:
+        config:
+          - groupname: admin
+            enabled: true
+            access_rights:
+              - admin
+            members:
+              - root
+          - groupname: netgrp
+            enabled: false
+            access_rights:
+              - admin
+            members: []
+        state: overridden
+      register: result
+
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Gather and verify only default groups remain
+      opengear.om.om_groups:
+        state: gathered
+      register: result
+
+    - name: Assert ansible-test group was removed
+      ansible.builtin.assert:
+        that:
+          - result.gathered | length == 2
+          - result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | list | length == 0
+
+  always:
+    - name: Cleanup - restore default state via overridden
+      opengear.om.om_groups:
+        config:
+          - groupname: admin
+            enabled: true
+            access_rights:
+              - admin
+          - groupname: netgrp
+            enabled: false
+            access_rights:
+              - admin
+        state: overridden
+
+# --- deleted ---
+- name: Test deleted
+  block:
+    - name: Setup - create group to delete
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+            enabled: true
+            access_rights:
+              - pmshell
+            ports: []
+        state: merged
+
+    - name: Delete group
+      opengear.om.om_groups:
+        config:
+          - groupname: ansible-test
+        state: deleted
+      register: result
+
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Gather and verify group is gone
+      opengear.om.om_groups:
+        state: gathered
+      register: result
+
+    - name: Assert group no longer exists
+      ansible.builtin.assert:
+        that:
+          - result.gathered | selectattr('groupname', 'equalto', 'ansible-test') | list | length == 0
+
+# --- deleted: idempotent ---
+- name: Delete non-existent group
+  opengear.om.om_groups:
+    config:
+      - groupname: ansible-test
+    state: deleted
+  register: result
+
+- name: Assert no change
+  ansible.builtin.assert:
+    that:
+      - result.changed == false

--- a/opengear/om/tests/unit/modules/network/om/test_om_groups.py
+++ b/opengear/om/tests/unit/modules/network/om/test_om_groups.py
@@ -108,6 +108,7 @@ class TestOmGroupsModule(TestOmModule):
                         'enabled': True,
                         'access_rights': ['pmshell', 'web_ui'],
                         'ports': ['ports-1', 'ports-2', 'ports-6'],
+                        'members': [],
                         'role': 'ConsoleUser',
                         'mode': 'scoped',
                     }


### PR DESCRIPTION
This is now ready for review, the patches can be rebase merged into develop/project-cleanup they both have independent value.

This introduces the integration tests for the facts and groups modules which run against a real test device, and also prevents the version check frm running against non-release branches.

Can be merged as soon as the unit tests pass again.