### PR TITLE
feat(ng/groups): Support --diff and --check mode

### DIFF
--- a/examples/playbooks/group_config.yaml
+++ b/examples/playbooks/group_config.yaml
@@ -10,7 +10,7 @@
           - groups
       register: facts_result
 
-    - name: Show current groups
+    - name: Show groups facts
       debug:
         var: facts_result
 
@@ -29,11 +29,6 @@
               - ports-2
               - ports-5
         state: merged
-      register: group_result
-
-    - name: Show current group
-      debug:
-        var: group_result
 
     # Modify the group to add an extra port, merged with current groups config
     - name: Increase scope of operators group (merge)
@@ -43,11 +38,6 @@
             ports:
               - ports-6
         state: merged
-      register: group_result
-
-    - name: Show current group
-      debug:
-        var: group_result
 
     # Reduce the access of the group, set expected state with replace.
     - name: Reduce access for operators group
@@ -65,19 +55,9 @@
               - ports-5
             members: []
         state: replaced
-      register: group_result
-
-    - name: Show current group
-      debug:
-        var: group_result
 
     - name: Delete operators group
       opengear.ng.groups:
         config:
           - groupname: operators
         state: deleted
-      register: group_result
-
-    - name: Show current group
-      debug:
-        var: group_result

--- a/opengear/ng/plugins/module_utils/config/groups.py
+++ b/opengear/ng/plugins/module_utils/config/groups.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from copy import deepcopy
+import json
 
 from ansible.module_utils.connection import ConnectionError
 
@@ -87,6 +88,20 @@ class Groups(ConfigBase):
                         if not exc.args[0].startswith('Expecting value:'):
                             raise exc
                         self.current_state.pop(group_id, None)
+            else:
+                # Simulate state changes for check mode + diff
+                for command in commands:
+                    if command['method'] == 'DELETE':
+                        group_id = command['path'].split('/')[-1]
+                        self.current_state.pop(group_id, None)
+                    elif command['method'] == 'PUT':
+                        group_id = command['path'].split('/')[-1]
+                        if group_id in self.current_state:
+                            self.current_state[group_id].update(command['data']['group'])
+                    elif command['method'] == 'POST':
+                        data = command['data']['group']
+                        temp_key = f"check-{data['groupname']}"
+                        self.current_state[temp_key] = data
             result['changed'] = True
 
         result['commands'] = commands
@@ -98,6 +113,36 @@ class Groups(ConfigBase):
             result['before'] = existing_groups_facts
             if result['changed']:
                 result['after'] = changed_groups_facts
+                if self._module._diff:
+                    diff_before = []
+                    diff_after = []
+
+                    # Build a lookup of existing groups by id
+                    existing_by_id = {g['id']: g for g in existing_groups_facts}
+
+                    for command in commands:
+                        if command['method'] == 'DELETE':
+                            group_id = command['path'].split('/')[-1]
+                            if group_id in existing_by_id:
+                                diff_before.append(existing_by_id[group_id])
+                                diff_after.append({})
+
+                        elif command['method'] == 'PUT':
+                            group_id = command['path'].split('/')[-1]
+                            if group_id in existing_by_id:
+                                before = existing_by_id[group_id]
+                                after = {**before, **command['data']['group']}
+                                diff_before.append(before)
+                                diff_after.append(after)
+
+                        elif command['method'] == 'POST':
+                            diff_before.append({})
+                            diff_after.append(command['data']['group'])
+
+                    result['diff'] = {
+                        'before': json.dumps(diff_before, indent=4) + '\n',
+                        'after': json.dumps(diff_after, indent=4) + '\n',
+                    }
         elif self.state == 'gathered':
             result['gathered'] = changed_groups_facts
 

--- a/opengear/ng/plugins/modules/groups.py
+++ b/opengear/ng/plugins/modules/groups.py
@@ -72,6 +72,11 @@ options:
     - gathered
     - rendered
     default: merged
+notes:
+  - Diff output shows the expected configuration change based on the commands
+    generated. It does not reflect the actual device state after execution,
+    which may differ due to device-side normalization or concurrent changes.
+    Use state=gathered after a run to verify the actual device state.
 """
 
 EXAMPLES = """

--- a/opengear/ng/tests/unit/modules/test_groups.py
+++ b/opengear/ng/tests/unit/modules/test_groups.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import json
+
 from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
 from ansible_collections.opengear.ng.plugins.modules import groups
 from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
@@ -268,3 +270,282 @@ class TestGroupsModule(TestModuleBase):
         self.assertEqual(groups[0]['groupname'], 'admin')
         self.assertEqual(groups[1]['groupname'], 'netgrp')
         self.assertEqual(groups[2]['groupname'], 'ansible-test')
+
+    def test_groups_check_mode(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            'config': [
+                {
+                    'groupname': 'ansible-test',
+                    'access_rights': ['web_ui'],
+                    'ports': ['ports-6'],
+                }
+            ],
+            'state': 'merged',
+        })
+
+        result = self.execute_module(changed=True)
+        # Commands should be generated
+        self.assertEqual(len(result['commands']), 1)
+        # But connection should never have been called
+        self.connection.return_value.send_request.assert_not_called()
+
+    def test_groups_diff_merged_update(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'ansible-test',
+                    'access_rights': ['web_ui'],
+                    'ports': ['ports-6'],
+                }
+            ],
+            'state': 'merged',
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 1)
+        self.assertEqual(len(after), 1)
+        self.assertEqual(before[0]['groupname'], 'ansible-test')
+        self.assertEqual(after[0]['groupname'], 'ansible-test')
+        self.assertIn('web_ui', after[0]['access_rights'])
+        self.assertIn('ports-6', after[0]['ports'])
+
+    def test_groups_diff_deleted(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': [
+                {'groupname': 'ansible-test'}
+            ],
+            'state': 'deleted',
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 1)
+        self.assertEqual(before[0]['groupname'], 'ansible-test')
+        self.assertEqual(after[0], {})
+
+    def test_groups_diff_overridden(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'admin',
+                    'description': 'Overridden groups, only admin remains',
+                    'enabled': True,
+                    'access_rights': ['admin'],
+                    'ports': [],
+                }
+            ],
+            'state': 'overridden',
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        # netgrp and ansible-test deleted, admin changed
+        self.assertEqual(len(before), 3)
+        self.assertEqual(len(after), 3)
+        deleted_groupnames = {g['groupname'] for g in before if g.get('groupname') not in
+                              {g.get('groupname') for g in after if g}}
+        self.assertIn('netgrp', deleted_groupnames)
+        self.assertIn('ansible-test', deleted_groupnames)
+
+    def test_groups_no_diff_when_not_requested(self):
+        set_module_args({
+            'config': [
+                {
+                    'groupname': 'ansible-test',
+                    'access_rights': ['web_ui'],
+                }
+            ],
+            'state': 'merged',
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertNotIn('diff', result)
+
+    def test_groups_no_diff_when_idempotent(self):
+        set_module_args({
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'admin',
+                    'description': 'Provides users with unlimited configuration and management privileges',
+                    'enabled': True,
+                    'access_rights': ['admin'],
+                }
+            ],
+            'state': 'merged',
+        })
+
+        result = self.execute_module(changed=False)
+        self.assertNotIn('diff', result)
+
+    def test_groups_check_mode_with_diff_merged(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'ansible-test',
+                    'access_rights': ['web_ui'],
+                    'ports': ['ports-6'],
+                }
+            ],
+            'state': 'merged',
+        })
+
+        result = self.execute_module(changed=True)
+
+        # Commands should be generated but not sent
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+
+        # Diff should show simulated after state
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 1)
+        self.assertEqual(len(after), 1)
+        self.assertEqual(before[0]['groupname'], 'ansible-test')
+        self.assertEqual(after[0]['groupname'], 'ansible-test')
+        self.assertIn('web_ui', after[0]['access_rights'])
+        self.assertIn('ports-6', after[0]['ports'])
+        # Verify before does not have the new values
+        self.assertNotIn('web_ui', before[0]['access_rights'])
+        self.assertNotIn('ports-6', before[0]['ports'])
+
+    def test_groups_check_mode_with_diff_replaced(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'ansible-test',
+                    'description': 'Test group',
+                    'enabled': True,
+                    'access_rights': ['web_ui'],
+                    'ports': ['ports-1'],
+                }
+            ],
+            'state': 'replaced',
+        })
+
+        result = self.execute_module(changed=True)
+
+        # Commands should be generated but not sent
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+
+        # Diff should show simulated after state
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 1)
+        self.assertEqual(len(after), 1)
+        self.assertEqual(before[0]['groupname'], 'ansible-test')
+        self.assertEqual(after[0]['groupname'], 'ansible-test')
+        # access_rights replaced - pmshell gone, web_ui added
+        self.assertNotIn('pmshell', after[0]['access_rights'])
+        self.assertIn('web_ui', after[0]['access_rights'])
+        # ports replaced - ports-2 gone, only ports-1 remains
+        self.assertNotIn('ports-2', after[0]['ports'])
+        self.assertEqual(after[0]['ports'], ['ports-1'])
+
+    def test_groups_check_mode_with_diff_overridden(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'admin',
+                    'description': 'Overridden groups, only admin remains',
+                    'enabled': True,
+                    'access_rights': ['admin'],
+                    'ports': [],
+                }
+            ],
+            'state': 'overridden',
+        })
+
+        result = self.execute_module(changed=True)
+
+        # Commands should be generated but not sent
+        self.assertEqual(len(result['commands']), 3)
+        self.connection.return_value.send_request.assert_not_called()
+
+        # Diff should show simulated after state
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 3)
+        self.assertEqual(len(after), 3)
+        deleted_groupnames = {g['groupname'] for g in before if g.get('groupname') not in
+                              {g.get('groupname') for g in after if g}}
+        self.assertIn('netgrp', deleted_groupnames)
+        self.assertIn('ansible-test', deleted_groupnames)
+
+    def test_groups_check_mode_with_diff_deleted(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': [
+                {'groupname': 'ansible-test'}
+            ],
+            'state': 'deleted',
+        })
+
+        result = self.execute_module(changed=True)
+
+        # Commands should be generated but not sent
+        self.assertEqual(len(result['commands']), 1)
+        self.connection.return_value.send_request.assert_not_called()
+
+        # Diff should show simulated after state
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 1)
+        self.assertEqual(before[0]['groupname'], 'ansible-test')
+        self.assertEqual(after[0], {})
+
+    def test_groups_check_mode_with_diff_overridden(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            '_ansible_diff': True,
+            'config': [
+                {
+                    'groupname': 'admin',
+                    'description': 'Overridden groups, only admin remains',
+                    'enabled': True,
+                    'access_rights': ['admin'],
+                    'ports': [],
+                }
+            ],
+            'state': 'overridden',
+        })
+
+        result = self.execute_module(changed=True)
+
+        # Commands should be generated but not sent
+        self.assertEqual(len(result['commands']), 3)
+        self.connection.return_value.send_request.assert_not_called()
+
+        # Diff should show simulated after state
+        self.assertIn('diff', result)
+        before = json.loads(result['diff']['before'])
+        after = json.loads(result['diff']['after'])
+        self.assertEqual(len(before), 3)
+        self.assertEqual(len(after), 3)
+        deleted_groupnames = {g['groupname'] for g in before if g.get('groupname') not in
+                              {g.get('groupname') for g in after if g}}
+        self.assertIn('netgrp', deleted_groupnames)
+        self.assertIn('ansible-test', deleted_groupnames)


### PR DESCRIPTION
This is a work-in-progress to see how feasible it is to support --check and --diff mode as requested in #5.

If this is successful, we can consider adding it to future supported modules.