### PR TITLE
fix(ng): Replace deprecated warnings usage in exit_json

### DIFF
--- a/opengear/ng/plugins/modules/auth.py
+++ b/opengear/ng/plugins/modules/auth.py
@@ -189,6 +189,8 @@ def main():
                            supports_check_mode=True)
 
     result = Auth(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/conns.py
+++ b/opengear/ng/plugins/modules/conns.py
@@ -149,6 +149,8 @@ def main():
                            supports_check_mode=True)
 
     result = Conns(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/facts.py
+++ b/opengear/ng/plugins/modules/facts.py
@@ -98,7 +98,9 @@ def main():
     ansible_facts, additional_warnings = result
     warnings.extend(additional_warnings)
 
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    for warning in warnings:
+        module.warn(warning)
+    module.exit_json(ansible_facts=ansible_facts)
 
 
 if __name__ == '__main__':

--- a/opengear/ng/plugins/modules/failover.py
+++ b/opengear/ng/plugins/modules/failover.py
@@ -103,6 +103,8 @@ def main():
                            supports_check_mode=True)
 
     result = Failover(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/groups.py
+++ b/opengear/ng/plugins/modules/groups.py
@@ -141,6 +141,8 @@ def main():
                            supports_check_mode=True)
 
     result = Groups(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/pdu.py
+++ b/opengear/ng/plugins/modules/pdu.py
@@ -197,6 +197,8 @@ def main():
                            supports_check_mode=True)
 
     result = Pdu(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/physifs.py
+++ b/opengear/ng/plugins/modules/physifs.py
@@ -233,6 +233,8 @@ def main():
                            supports_check_mode=True)
 
     result = Physifs(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/ports.py
+++ b/opengear/ng/plugins/modules/ports.py
@@ -232,6 +232,8 @@ def main():
                            supports_check_mode=True)
 
     result = Ports(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/services.py
+++ b/opengear/ng/plugins/modules/services.py
@@ -430,6 +430,8 @@ def main():
                            supports_check_mode=True)
 
     result = Services(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/static_routes.py
+++ b/opengear/ng/plugins/modules/static_routes.py
@@ -151,6 +151,8 @@ def main():
                            supports_check_mode=True)
 
     result = StaticRoutes(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/system.py
+++ b/opengear/ng/plugins/modules/system.py
@@ -197,6 +197,8 @@ def main():
                            supports_check_mode=True)
 
     result = System(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/plugins/modules/users.py
+++ b/opengear/ng/plugins/modules/users.py
@@ -135,6 +135,8 @@ def main():
                            supports_check_mode=True)
 
     result = Users(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
     module.exit_json(**result)
 
 

--- a/opengear/ng/tests/unit/modules/conftest.py
+++ b/opengear/ng/tests/unit/modules/conftest.py
@@ -10,7 +10,7 @@ import json
 import pytest
 
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 
 

--- a/opengear/ng/tests/unit/modules/test_groups.py
+++ b/opengear/ng/tests/unit/modules/test_groups.py
@@ -234,11 +234,11 @@ class TestGroupsModule(TestModuleBase):
             'state': 'merged',
         })
 
-        result = self.execute_module(changed=True)
-        self.assertIn(
-            "The 'role' field is deprecated since 2022/08. Use 'access_rights' instead.",
-            result['warnings']
-        )
+        with patch('ansible.module_utils.basic.AnsibleModule.warn') as mock_warn:
+            self.execute_module(changed=True)
+            mock_warn.assert_called_once_with(
+                "The 'role' field is deprecated since 2022/08. Use 'access_rights' instead."
+            )
 
     def test_groups_rendered(self):
         set_module_args({

--- a/opengear/ng/tests/unit/modules/utils.py
+++ b/opengear/ng/tests/unit/modules/utils.py
@@ -10,7 +10,7 @@ import json
 from ansible_collections.opengear.ng.tests.unit.compat import unittest
 from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def set_module_args(args):


### PR DESCRIPTION
Replace passing warnings directly to exit_json with module.warn(), which will become an error in ansible-core 2.23.