### PR TITLE
ci: Restrict automatic integration tests to upstream repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,13 @@ jobs:
     needs: [lint, sanity, unit-test]
     runs-on: [self-hosted, ansible, integration-tests]
     environment: integration-tests
-    # automatically run on main branch and release branches
+    # automatically run on main branch and release branches with opengear repo only
     # manual trigger with run_integration
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')) ||
+      (github.event_name == 'push' && github.repository == 'opengear/ansible-ng' && (
+         github.ref == 'refs/heads/main' ||
+         startsWith(github.ref, 'refs/heads/release/')
+       )) ||
       (github.event_name == 'workflow_dispatch' && inputs.run_integration)
     steps:
       - name: Checkout


### PR DESCRIPTION
Prevent integration test job from queuing indefinitely on forks by gating automatic runs to opengear/ansible-ng only.

Manual workflow_dispatch trigger remains available for contributors with their own runner and environment.