### PR TITLE
fix(groups): Handle empty DELETE response

### DIFF
--- a/plugins/module_utils/config/groups.py
+++ b/plugins/module_utils/config/groups.py
@@ -80,7 +80,10 @@ class Groups(ConfigBase):
                         group_id = command['path'].split('/')[-1]
                     try:
                         response = self._connection.send_request(command['data'], command['path'], command['method'])
-                        if group_id and command['method'] == 'PUT':
+                        if command['method'] == 'DELETE':
+                            # Delete returns no response body
+                            self.current_state.pop(group_id, None)
+                        elif group_id and command['method'] == 'PUT':
                             self.current_state[group_id] = response['group']
                         else:
                             self.current_state[response['group']['id']] = response['group']


### PR DESCRIPTION
DELETE operations return a 204 No Content response which was previously handled by chance via exception suppression in handle_response. Now explicitly handled by removing the group from current_state on DELETE rather than attempting to parse the empty response body.

This has been tested by running the example group_config playbook on a device, which presently is the only module tested by the integration tests, so it should pass on merge to main and resolve the integration tests.