### PR TITLE
Feature/user authorized keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,22 @@ Modules in this collection use the Ansible `httpapi` connection plugin by defaul
 to communicate with Opengear devices via the REST API.
 
 ## Modules
-| Name                         | Description                                                                                          |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
-| opengear.ng.auth             | Manage remote authentication, authorization, and accounting (AAA) configuration.                     |
-| opengear.ng.conns            | Manage network connection configuration.                                                             |
-| opengear.ng.facts            | Gather device information and network resource configuration facts.                                  |
-| opengear.ng.failover         | Manage failover configuration and retrieve failover status.                                          |
-| opengear.ng.firmware_upgrade | Manage firmware upgrades on Opengear devices.                                                        |
-| opengear.ng.groups           | Manage user group configuration.                                                                     |
-| opengear.ng.pdu              | Manage PDUs connected to the device, including configuration, monitoring, and control.               |
-| opengear.ng.physifs          | Manage physical network interface configuration.                                                     |
-| opengear.ng.ports            | Manage serial port configuration.                                                                    |
-| opengear.ng.services         | Manage system service configuration.                                                                 |
-| opengear.ng.static_routes    | Manage static route configuration.                                                                   |
-| opengear.ng.system           | Manage device system configuration and retrieve device information.                                  |
-| opengear.ng.users            | Manage user configuration.                                                                           |
+| Name                             | Description                                                                                          |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| opengear.ng.auth                 | Manage remote authentication, authorization, and accounting (AAA) configuration.                     |
+| opengear.ng.conns                | Manage network connection configuration.                                                             |
+| opengear.ng.facts                | Gather device information and network resource configuration facts.                                  |
+| opengear.ng.failover             | Manage failover configuration and retrieve failover status.                                          |
+| opengear.ng.firmware_upgrade     | Manage firmware upgrades on Opengear devices.                                                        |
+| opengear.ng.groups               | Manage user group configuration.                                                                     |
+| opengear.ng.pdu                  | Manage PDUs connected to the device, including configuration, monitoring, and control.               |
+| opengear.ng.physifs              | Manage physical network interface configuration.                                                     |
+| opengear.ng.ports                | Manage serial port configuration.                                                                    |
+| opengear.ng.services             | Manage system service configuration.                                                                 |
+| opengear.ng.static_routes        | Manage static route configuration.                                                                   |
+| opengear.ng.system               | Manage device system configuration and retrieve device information.                                  |
+| opengear.ng.user_authorized_keys | Manage configuration of user authorized keys on Opengear devices.                                    |
+| opengear.ng.users                | Manage user configuration.                                                                           |
 
 ## Installing The Collection
 

--- a/examples/playbooks/user_authorized_keys_config.yaml
+++ b/examples/playbooks/user_authorized_keys_config.yaml
@@ -1,0 +1,58 @@
+---
+- name: Example playbook for managing user authorized keys
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    - name: Gather user_authorized_keys facts
+      opengear.ng.facts:
+        gather_network_resources:
+          - user_authorized_keys
+      register: facts_result
+
+    - name: Show user_authorized_keys facts
+      ansible.builtin.debug:
+        var: facts_result
+
+    # Create user authorized keys, merged with the existing keys for that user
+    - name: Create user_authorized_keys
+      opengear.ng.user_authorized_keys:
+        config:
+          - username: root
+            keys:
+              - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDPHCFeZyNzcdF4S1o4slJrdSuAJ8t36i4X0Kr9UUbDz/4W/XyqpFPT3Hw5HI\
+                 LT1lNbuX85FbGekrDQfqUmfCctPtVuVExchLL8O6zaV4fyQzDAshe1gU+wDOyW7INK6tla6F2BX4XZndwS+8VWF9ur30dRwFe4vE4q4vdnSRaTMQ== user@example.com"
+              - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoIUqQoc2qsvbCUcs86mwG+zNSJfNJJVJTXXd1VC1Qm user@example.com"
+        state: merged
+
+    # Replace authorized keys for a user
+    - name: Replace list of authorized keys for a user
+      opengear.ng.user_authorized_keys:
+        config:
+          - username: root
+            keys:
+              - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDPHCFeZyNzcdF4S1o4slJrdSuAJ8t36i4X0Kr9UUbDz/4W/XyqpFPT3Hw5HI\
+                 LT1lNbuX85FbGekrDQfqUmfCctPtVuVExchLL8O6zaV4fyQzDAshe1gU+wDOyW7INK6tla6F2BX4XZndwS+8VWF9ur30dRwFe4vE4q4vdnSRaTMQ== user@example.com"
+              - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoIUqQoc2qsvbCUcs86mwG+zNSJfNJJVJTXXd1VC1Qm user@example2.com"
+        state: replaced
+
+    # Delete specific authorized key for a user
+    - name: Delete authorized key for a user
+      opengear.ng.user_authorized_keys:
+        config:
+          - username: root
+            keys:
+              - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDPHCFeZyNzcdF4S1o4slJrdSuAJ8t36i4X0Kr9UUbDz/4W/XyqpFPT3Hw5HI\
+                 LT1lNbuX85FbGekrDQfqUmfCctPtVuVExchLL8O6zaV4fyQzDAshe1gU+wDOyW7INK6tla6F2BX4XZndwS+8VWF9ur30dRwFe4vE4q4vdnSRaTMQ== user@example.com"
+        state: deleted
+
+    # Delete all authorized keys for a user
+    - name: Delete authorized key for a user
+      opengear.ng.user_authorized_keys:
+        config:
+          - username: root
+            keys:
+              - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDPHCFeZyNzcdF4S1o4slJrdSuAJ8t36i4X0Kr9UUbDz/4W/XyqpFPT3Hw5HI\
+                 LT1lNbuX85FbGekrDQfqUmfCctPtVuVExchLL8O6zaV4fyQzDAshe1gU+wDOyW7INK6tla6F2BX4XZndwS+8VWF9ur30dRwFe4vE4q4vdnSRaTMQ== user@example.com"
+              - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoIUqQoc2qsvbCUcs86mwG+zNSJfNJJVJTXXd1VC1Qm user@example2.com"
+        state: deleted

--- a/plugins/module_utils/argspec/facts.py
+++ b/plugins/module_utils/argspec/facts.py
@@ -30,6 +30,7 @@ class FactsArgs(object):  # pylint: disable=R0903
         "services",
         "static_routes",
         "system",
+        "user_authorized_keys",
         "users",
     ]
 

--- a/plugins/module_utils/argspec/user_authorized_keys.py
+++ b/plugins/module_utils/argspec/user_authorized_keys.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class UserAuthorizedKeysArgs(object):  # pylint: disable=R0903
+    """
+    Argument specification for the user_authorized_keys module.
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    argument_spec = {
+        "config": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "username": {
+                    "type": "str",
+                    "required": True,
+                },
+                "keys": {
+                    "type": "list",
+                    "elements": "str",
+                    'no_log': False,
+                },
+            },
+        },
+        "state": {
+            "type": "str",
+            "default": "merged",
+            "choices": [
+                "merged",
+                "replaced",
+                "deleted",
+                "gathered",
+            ],
+        },
+    }

--- a/plugins/module_utils/config/user_authorized_keys.py
+++ b/plugins/module_utils/config/user_authorized_keys.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from copy import deepcopy
+import json
+
+from ansible.module_utils.connection import ConnectionError
+
+from ansible_collections.opengear.ng.plugins.module_utils.config.base import ConfigBase
+from ansible_collections.opengear.ng.plugins.module_utils.facts.facts import Facts
+from ansible_collections.opengear.ng.plugins.module_utils.utils.utils import (
+    to_list,
+)
+
+
+class UserAuthorizedKeys(ConfigBase):
+    """
+    The user_authorized_keys class
+    """
+
+    gather_subset = [
+        '!all',
+        '!min',
+    ]
+
+    gather_network_resources = [
+        'user_authorized_keys',
+    ]
+
+    def __init__(self, module):
+        super(UserAuthorizedKeys, self).__init__(module)
+
+    def get_user_authorized_keys_facts(self):
+        """ Get the 'facts' (the current configuration)
+
+        :rtype: A list
+        :returns: The current configuration as a list
+        """
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts_data = facts['ansible_network_resources'].get('user_authorized_keys')
+        if not facts_data:
+            return []
+        return facts_data
+
+    def execute_module(self):
+        """ Execute the module
+
+        :rtype: A dictionary
+        :returns: The result from module execution
+        """
+        result = {'changed': False}
+        warnings = list()
+        commands = list()
+
+        # ----------------------
+        # Get facts
+        # ----------------------
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            existing_facts = self.get_user_authorized_keys_facts()
+        else:
+            existing_facts = []
+        # ----------------------
+        # Prepare commands
+        # ----------------------
+        if self.state in self.ACTION_STATES:
+            commands.extend(self.set_config(existing_facts))
+        if commands and self.state in self.ACTION_STATES:
+            if not self._module.check_mode:
+                for command in commands:
+                    try:
+                        self._connection.send_request(command['data'], command['path'], command['method'])
+                    except ConnectionError as exc:
+                        if not exc.args[0].startswith('Expecting value:'):
+                            raise exc
+            result['changed'] = True
+
+            if self._module._diff:
+                result['diff'] = self._build_diff(commands, existing_facts)
+        # --------------------------
+        # Prepare result
+        # --------------------------
+        result['commands'] = commands
+
+        if self.state in self.ACTION_STATES:
+            changed_facts = self.get_user_authorized_keys_facts()
+            result['before'] = existing_facts
+            if result['changed']:
+                result['after'] = changed_facts
+        elif self.state == 'gathered':
+            result['gathered'] = existing_facts
+
+        result['warnings'] = warnings
+        return result
+
+    def set_config(self, existing_facts):
+        """ Collect the configuration from the args passed to the module,
+            collect the current configuration (as a dict from facts)
+
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        want = self._module.params['config']
+        have = existing_facts
+        resp = self.set_state(want, have)
+        return to_list(resp)
+
+    def set_state(self, want, have):
+        """ Select the appropriate function based on the state provided
+
+        :param want: the desired configuration as a list
+        :param have: the current configuration as a list
+        :rtype: A list
+        :returns: the commands necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        # Build lookup maps from have:
+        # username -> user_id
+        # username -> {key_string -> key_id}
+        username_id_map = {}
+        username_keys_map = {}
+
+        for entry in have:
+            username = entry['username']
+            username_id_map[username] = entry['user_id']
+            username_keys_map[username] = {
+                k['key']: k['id'] for k in entry.get('keys', [])
+            }
+
+        state = self._module.params['state']
+        if state == 'deleted':
+            commands = self._state_deleted(want, username_id_map, username_keys_map)
+        elif state == 'merged':
+            commands = self._state_merged(want, username_id_map, username_keys_map)
+        elif state == 'replaced':
+            commands = self._state_replaced(want, username_id_map, username_keys_map)
+        else:
+            commands = []
+        return commands
+
+    @staticmethod
+    def _build_diff(commands, existing_facts):
+        """ Build a before/after diff scoped to users whose keys changed.
+
+        :param commands: the list of commands that will be (or would be) sent
+        :param existing_facts: the current authorized keys facts
+        :rtype: dict
+        :returns: a dict with 'before' and 'after' keys, each a JSON string
+                  showing only the users whose keys are affected
+        """
+        # Build a lookup of existing key lists by username, keyed by user_id
+        # so commands (which reference user_id in the path) can be matched
+        # back to a username.
+        user_id_to_username = {entry['user_id']: entry['username'] for entry in existing_facts}
+        before_keys = {entry['username']: list(k['key'] for k in entry.get('keys', [])) for entry in existing_facts}
+        after_keys = deepcopy(before_keys)
+
+        affected_usernames = set()
+
+        for command in commands:
+            # path is one of:
+            #   users/{user_id}/ssh/authorized_keys           (POST)
+            #   users/{user_id}/ssh/authorized_keys/{key_id}   (DELETE)
+            parts = command['path'].split('/')
+            user_id = parts[1]
+            username = user_id_to_username.get(user_id)
+            if not username:
+                continue
+            affected_usernames.add(username)
+
+            if command['method'] == 'POST':
+                key = command['data']['authorized_key']['key']
+                after_keys.setdefault(username, [])
+                if key not in after_keys[username]:
+                    after_keys[username].append(key)
+            elif command['method'] == 'DELETE':
+                key_id = parts[-1]
+                # Find the key string matching this key_id from existing facts
+                entry = next((e for e in existing_facts if e['username'] == username), None)
+                if entry:
+                    key = next((k['key'] for k in entry.get('keys', []) if k['id'] == key_id), None)
+                    if key and key in after_keys.get(username, []):
+                        after_keys[username].remove(key)
+
+        diff_before = [
+            {'username': u, 'keys': before_keys.get(u, [])}
+            for u in affected_usernames
+        ]
+        diff_after = [
+            {'username': u, 'keys': after_keys.get(u, [])}
+            for u in affected_usernames
+        ]
+
+        return {
+            'before': json.dumps(diff_before, indent=4) + '\n',
+            'after': json.dumps(diff_after, indent=4) + '\n',
+        }
+
+    @staticmethod
+    def _state_merged(want, username_id_map, username_keys_map):
+        """ The command generator when state is merged
+
+        Adds keys not already present. Existing keys are preserved.
+
+        :rtype: A list
+        :returns: the commands necessary to merge the provided into
+                  the current configuration
+        """
+        commands = []
+        for entry in want:
+            username = entry['username']
+            user_id = username_id_map.get(username)
+            if not user_id:
+                raise ValueError(f"User '{username}' not found. Ensure the user exists before managing authorized keys.")
+
+            existing_keys = username_keys_map.get(username, {})
+            for key in entry.get('keys', []):
+                if key not in existing_keys:
+                    commands.append({
+                        'path': f'users/{user_id}/ssh/authorized_keys',
+                        'data': {'authorized_key': {'key': key}},
+                        'method': 'POST',
+                    })
+        return commands
+
+    @staticmethod
+    def _state_replaced(want, username_id_map, username_keys_map):
+        """ The command generator when state is replaced
+
+        Replaces all keys for the user with only those specified.
+        Keys not in want are deleted. Keys not yet present are added.
+
+        :rtype: A list
+        :returns: the commands necessary to replace the current configuration
+        """
+        commands = []
+        for entry in want:
+            username = entry['username']
+            user_id = username_id_map.get(username)
+            if not user_id:
+                raise ValueError(f"User '{username}' not found. Ensure the user exists before managing authorized keys.")
+
+            want_keys = set(entry.get('keys', []))
+            existing_keys = username_keys_map.get(username, {})
+
+            # DELETE keys not in want
+            for key, key_id in existing_keys.items():
+                if key not in want_keys:
+                    commands.append({
+                        'path': f'users/{user_id}/ssh/authorized_keys/{key_id}',
+                        'data': None,
+                        'method': 'DELETE',
+                    })
+
+            # POST keys not already present
+            for key in want_keys:
+                if key not in existing_keys:
+                    commands.append({
+                        'path': f'users/{user_id}/ssh/authorized_keys',
+                        'data': {'authorized_key': {'key': key}},
+                        'method': 'POST',
+                    })
+        return commands
+
+    @staticmethod
+    def _state_deleted(want, username_id_map, username_keys_map):
+        """ The command generator when state is deleted
+
+        Removes the specified keys from the user.
+
+        :rtype: A list
+        :returns: the commands necessary to delete the specified keys
+        """
+        commands = []
+        for entry in want:
+            username = entry['username']
+            user_id = username_id_map.get(username)
+            if not user_id:
+                raise ValueError(f"User '{username}' not found. Ensure the user exists before managing authorized keys.")
+
+            existing_keys = username_keys_map.get(username, {})
+            for key in entry.get('keys', []):
+                key_id = existing_keys.get(key)
+                if key_id:
+                    commands.append({
+                        'path': f'users/{user_id}/ssh/authorized_keys/{key_id}',
+                        'data': None,
+                        'method': 'DELETE',
+                    })
+                # if key not found in have, nothing to delete (idempotent)
+        return commands

--- a/plugins/module_utils/facts/facts.py
+++ b/plugins/module_utils/facts/facts.py
@@ -21,6 +21,7 @@ from ansible_collections.opengear.ng.plugins.module_utils.facts.ports import Por
 from ansible_collections.opengear.ng.plugins.module_utils.facts.services import ServicesFacts
 from ansible_collections.opengear.ng.plugins.module_utils.facts.static_routes import StaticRoutesFacts
 from ansible_collections.opengear.ng.plugins.module_utils.facts.system import SystemFacts
+from ansible_collections.opengear.ng.plugins.module_utils.facts.user_authorized_keys import UserAuthorizedKeysFacts
 from ansible_collections.opengear.ng.plugins.module_utils.facts.users import UsersFacts
 
 
@@ -34,6 +35,7 @@ FACT_RESOURCE_SUBSETS = dict(
     pdu=PduFacts,
     physifs=PhysifsFacts,
     ports=PortsFacts,
+    user_authorized_keys=UserAuthorizedKeysFacts,
     users=UsersFacts,
     services=ServicesFacts,
     static_routes=StaticRoutesFacts,

--- a/plugins/module_utils/facts/user_authorized_keys.py
+++ b/plugins/module_utils/facts/user_authorized_keys.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from copy import deepcopy
+
+from ansible_collections.opengear.ng.plugins.module_utils.utils import utils
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.user_authorized_keys import UserAuthorizedKeysArgs
+
+
+class UserAuthorizedKeysFacts(object):
+    """ The user_authorized_keys facts class
+    """
+
+    def __init__(self, module, subspec='config', options='options'):
+        self._module = module
+        self.argument_spec = UserAuthorizedKeysArgs.argument_spec
+        spec = deepcopy(self.argument_spec)
+        if subspec:
+            if options:
+                facts_argument_spec = spec[subspec][options]
+            else:
+                facts_argument_spec = spec[subspec]
+        else:
+            facts_argument_spec = spec
+
+        self.generated_spec = utils.generate_dict(facts_argument_spec)
+
+    def get_users(self, connection):
+        """ Fetch all users to build username -> user_id map """
+        return connection.get(None, 'users', query_params=None)['users']
+
+    def get_device_data(self, connection, user_id):
+        """ Fetch authorized keys for a specific user """
+        return connection.get(None, f'users/{user_id}/ssh/authorized_keys', query_params=None).get('authorized_keys', [])
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        """ Populate the facts for user_authorized_keys
+
+        :param connection: the device connection
+        :param ansible_facts: Facts dictionary
+        :param data: previously collected conf
+        :rtype: dictionary
+        :returns: facts
+        """
+        objs = []
+
+        if data:
+            # data passed directly (e.g. from gathered state in tests)
+            objs = data
+        else:
+            # fetch users to get username -> id mapping
+            users = self.get_users(connection)
+            for user in users:
+                user_id = user['id']
+                username = user['username']
+                raw_keys = self.get_device_data(connection, user_id)
+
+                # preserve id and key string internally for DELETE path resolution
+                # key_fingerprint is informational only, not included
+                keys = [
+                    {'id': k['id'], 'key': k['key']}
+                    for k in raw_keys
+                ]
+
+                # add all users to facts output so that merged state is able to
+                # add keys
+                objs.append({
+                    'username': username,
+                    'user_id': user_id,
+                    'keys': keys,
+                })
+
+        ansible_facts['ansible_network_resources'].pop('user_authorized_keys', None)
+        facts = {}
+        if objs:
+            facts['user_authorized_keys'] = objs
+
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -52,6 +52,7 @@ options:
       - services
       - static_routes
       - system
+      - user_authorized_keys
       - users
     version_added: '1.0.0'
 """

--- a/plugins/modules/user_authorized_keys.py
+++ b/plugins/modules/user_authorized_keys.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'opengear'
+}
+
+DOCUMENTATION = """
+---
+module: user_authorized_keys
+version_added: '1.0.0'
+short_description: Manages configuration of user authorized keys on Opengear devices
+description:
+  - Manages configuration of user SSH authorized keys on Opengear devices
+  - Authorized keys are scoped to a specific user, identified by username.
+  - The user must already exist before managing their authorized keys.
+author:
+  - Opengear (@opengear)
+options:
+  config:
+    description: Manage configuration of user authorized keys on Opengear devices
+    type: list
+    elements: dict
+    suboptions:
+      username:
+        type: str
+        description: The username of the user whose authorized keys are being managed.
+        required: true
+      keys:
+        type: list
+        elements: str
+        description: List of SSH public key strings to manage for this user.
+  state:
+    description:
+      - The state of the configuration after module completion.
+    type: str
+    choices:
+      - merged
+      - replaced
+      - deleted
+      - gathered
+    default: merged
+notes:
+  - Diff output shows the expected configuration change based on the commands
+    generated. It does not reflect the actual device state after execution,
+    which may differ due to device-side normalization or concurrent changes.
+    Use state=gathered after a run to verify the actual device state.
+  - Offline rendering of commands is not supported as resolving usernames to
+    user ids requires device connection.
+"""
+
+EXAMPLES = """
+- name: Add authorized keys for a user
+  opengear.ng.user_authorized_keys:
+    config:
+      - username: netops
+        keys:
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c... netops@laptop"
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcsp... netops@workstation"
+    state: merged
+
+- name: Replace all authorized keys for a user
+  opengear.ng.user_authorized_keys:
+    config:
+      - username: netops
+        keys:
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c... netops@laptop"
+    state: replaced
+
+- name: Delete specific authorized keys for a user
+  opengear.ng.user_authorized_keys:
+    config:
+      - username: netops
+        keys:
+          - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c... netops@laptop"
+    state: deleted
+
+- name: Gather authorized keys facts
+  opengear.ng.facts:
+    gather_network_resources:
+      - user_authorized_keys
+"""
+
+RETURN = """
+before:
+  description: The configuration before the module is executed.
+  returned: always
+  type: dict
+after:
+  description: The configuration after the module is executed.
+  returned: when changed
+  type: dict
+commands:
+  description: The set of commands pushed to the remote device.
+  returned: always
+  type: list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.user_authorized_keys import UserAuthorizedKeysArgs
+from ansible_collections.opengear.ng.plugins.module_utils.config.user_authorized_keys import UserAuthorizedKeys
+
+
+def main():
+    """
+    Main entry point for module execution
+
+    :returns: the result form module invocation
+    """
+    module = AnsibleModule(argument_spec=UserAuthorizedKeysArgs.argument_spec,
+                           supports_check_mode=True)
+
+    result = UserAuthorizedKeys(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/modules/fixtures/user_authorized_keys_config.cfg
+++ b/tests/unit/modules/fixtures/user_authorized_keys_config.cfg
@@ -1,0 +1,21 @@
+[
+    {
+        "username": "user1",
+        "user_id": "users-1",
+        "keys": [
+            {
+                "id": "users_ssh_authorized_keys-1",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop"
+            },
+            {
+                "id": "users_ssh_authorized_keys-2",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcsp user1@workstation"
+            }
+        ]
+    },
+    {
+        "username": "user2",
+        "user_id": "users-2",
+        "keys": []
+    }
+]

--- a/tests/unit/modules/test_facts.py
+++ b/tests/unit/modules/test_facts.py
@@ -32,6 +32,28 @@ class TestFactsModule(TestModuleBase):
             ]
             return mock
 
+        def _setup_user_authorized_keys_mocks(self):
+            mock_users = patch(
+                "ansible_collections.opengear.ng.plugins.module_utils."
+                "facts.user_authorized_keys.UserAuthorizedKeysFacts.get_users"
+            )
+            mock_users.start().return_value = [
+                {'username': 'user1', 'id': 'users-1', 'enabled': True},
+                {'username': 'user2', 'id': 'users-2', 'enabled': True},
+            ]
+            mock_keys = patch(
+                "ansible_collections.opengear.ng.plugins.module_utils."
+                "facts.user_authorized_keys.UserAuthorizedKeysFacts.get_device_data"
+            )
+            mock_keys.start().return_value = [
+                {
+                    "id": "users_ssh_authorized_keys-1",
+                    "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoIUqQoc2qsvbCUcs86mwG+zNSJfNJJVJTXXd1VC1Qm user@example2.com",
+                    "key_fingerprint": "256 SHA256:LyY9x0V/6FKZRi7eMkEjQ2XNjdkgm9rH+GdBh3IeJ2Q user@example2.com (ED25519)",
+                }
+            ]
+            return mock_users, mock_keys
+
         def _setup_groups_mocks(self):
             mock = patch(
                 "ansible_collections.opengear.ng.plugins.module_utils."
@@ -61,6 +83,7 @@ class TestFactsModule(TestModuleBase):
             return mock_version, mock_status
 
         self.mock_users = _setup_users_mocks(self)
+        self.mock_uak_users, self.mock_uak_keys = _setup_user_authorized_keys_mocks(self)
         self.mock_groups = _setup_groups_mocks(self)
         self.mock_fw_version, self.mock_fw_status = _setup_firmware_upgrade_mocks(self)
 
@@ -73,6 +96,8 @@ class TestFactsModule(TestModuleBase):
     def tearDown(self):
         super(TestFactsModule, self).tearDown()
         self.mock_users.stop()
+        self.mock_uak_users.stop()
+        self.mock_uak_keys.stop()
         self.mock_groups.stop()
         self.mock_fw_version.stop()
         self.mock_fw_status.stop()
@@ -89,6 +114,14 @@ class TestFactsModule(TestModuleBase):
         self.assertIn('ansible_facts', result)
         self.assertIn('ansible_network_resources', result['ansible_facts'])
         self.assertIn('users', result['ansible_facts']['ansible_network_resources'])
+
+    def test_facts_gather_user_authorized_keys(self):
+        """Facts module dispatches correctly to user_authorized_keys facts class"""
+        set_module_args({'gather_network_resources': ['user_authorized_keys']})
+        result = self.execute_module(changed=False)
+
+        self.assertIn('ansible_facts', result)
+        self.assertIn('ansible_network_resources', result['ansible_facts'])
 
     def test_facts_gather_groups(self):
         """Facts module dispatches correctly to groups facts class"""

--- a/tests/unit/modules/test_user_authorized_keys.py
+++ b/tests/unit/modules/test_user_authorized_keys.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import user_authorized_keys
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase, load_fixture
+
+
+class TestUserAuthorizedKeysModule(TestModuleBase):
+
+    module = user_authorized_keys
+
+    def setUp(self):
+        super(TestUserAuthorizedKeysModule, self).setUp()
+        self.maxDiff = None
+
+        # Mock the users lookup (get_users) used to build username -> user_id map
+        self.mock_get_users = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.user_authorized_keys.UserAuthorizedKeysFacts.get_users"
+        )
+        self.get_users = self.mock_get_users.start()
+
+        # Mock the per-user key fetch
+        self.mock_get_device_data = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.user_authorized_keys.UserAuthorizedKeysFacts.get_device_data"
+        )
+        self.get_device_data = self.mock_get_device_data.start()
+
+        self.mock_connection = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "config.base.Connection"
+        )
+        self.connection = self.mock_connection.start()
+
+    def tearDown(self):
+        super(TestUserAuthorizedKeysModule, self).tearDown()
+        self.mock_get_users.stop()
+        self.mock_get_device_data.stop()
+        self.mock_connection.stop()
+
+    def load_fixtures(self, commands=None):
+        fixture = load_fixture("user_authorized_keys_config.cfg")
+
+        # get_users returns a list of {username, id} dicts
+        self.get_users.return_value = [
+            {'username': entry['username'], 'id': entry['user_id']}
+            for entry in fixture
+        ]
+
+        # get_device_data is called per user_id, return that user's keys
+        key_map = {entry['user_id']: entry['keys'] for entry in fixture}
+
+        def load_keys_for_user(*args, **kwargs):
+            user_id = [k for k in key_map if k in args[1]][0]
+            return key_map[user_id]
+
+        self.get_device_data.side_effect = load_keys_for_user
+
+    # --- merged ---
+    def test_user_authorized_keys_merged_add_key(self):
+        """Add a new key to a user that already has keys"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop',
+                        'ssh-rsa AAAAB3NzaC1yc2NEWKEY user1@newhost',
+                    ]
+                }
+            ],
+            'state': 'merged',
+        })
+
+        commands = [
+            {
+                'path': 'users/users-1/ssh/authorized_keys',
+                'data': {'authorized_key': {'key': 'ssh-rsa AAAAB3NzaC1yc2NEWKEY user1@newhost'}},
+                'method': 'POST',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_user_authorized_keys_merged_idempotent(self):
+        """Merging keys already present should produce no commands"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop',
+                    ]
+                }
+            ],
+            'state': 'merged',
+        })
+
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_user_authorized_keys_merged_new_user(self):
+        """Add keys to a user that has no existing keys"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user2',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2NEWKEY user2@laptop',
+                    ]
+                }
+            ],
+            'state': 'merged',
+        })
+
+        commands = [
+            {
+                'path': 'users/users-2/ssh/authorized_keys',
+                'data': {'authorized_key': {'key': 'ssh-rsa AAAAB3NzaC1yc2NEWKEY user2@laptop'}},
+                'method': 'POST',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    # --- replaced ---
+    def test_user_authorized_keys_replaced(self):
+        """Replace all keys for a user - removes old keys, adds new ones"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2NEWKEY user1@newhost',
+                    ]
+                }
+            ],
+            'state': 'replaced',
+        })
+
+        commands = [
+            {
+                'path': 'users/users-1/ssh/authorized_keys/users_ssh_authorized_keys-1',
+                'data': None,
+                'method': 'DELETE',
+            },
+            {
+                'path': 'users/users-1/ssh/authorized_keys/users_ssh_authorized_keys-2',
+                'data': None,
+                'method': 'DELETE',
+            },
+            {
+                'path': 'users/users-1/ssh/authorized_keys',
+                'data': {'authorized_key': {'key': 'ssh-rsa AAAAB3NzaC1yc2NEWKEY user1@newhost'}},
+                'method': 'POST',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_user_authorized_keys_replaced_idempotent(self):
+        """Replacing with the same keys should produce no commands"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop',
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcsp user1@workstation',
+                    ]
+                }
+            ],
+            'state': 'replaced',
+        })
+
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    # --- deleted ---
+    def test_user_authorized_keys_deleted(self):
+        """Delete a specific key from a user"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop',
+                    ]
+                }
+            ],
+            'state': 'deleted',
+        })
+
+        commands = [
+            {
+                'path': 'users/users-1/ssh/authorized_keys/users_ssh_authorized_keys-1',
+                'data': None,
+                'method': 'DELETE',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_user_authorized_keys_deleted_idempotent(self):
+        """Deleting a key that doesn't exist should produce no commands"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2NONEXISTENT user1@ghost',
+                    ]
+                }
+            ],
+            'state': 'deleted',
+        })
+
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_user_authorized_keys_deleted_all(self):
+        """Delete all keys for a user"""
+        set_module_args({
+            'config': [
+                {
+                    'username': 'user1',
+                    'keys': [
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRO6c user1@laptop',
+                        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcsp user1@workstation',
+                    ]
+                }
+            ],
+            'state': 'deleted',
+        })
+
+        commands = [
+            {
+                'path': 'users/users-1/ssh/authorized_keys/users_ssh_authorized_keys-1',
+                'data': None,
+                'method': 'DELETE',
+            },
+            {
+                'path': 'users/users-1/ssh/authorized_keys/users_ssh_authorized_keys-2',
+                'data': None,
+                'method': 'DELETE',
+            }
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    # --- gathered ---
+    def test_user_authorized_keys_gathered(self):
+        """Gathered state returns current authorized keys structured by user"""
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        result = self.execute_module(changed=False)
+
+        self.assertIn('gathered', result)
+        gathered = result['gathered']
+        self.assertEqual(len(gathered), 2)
+        self.assertEqual(gathered[0]['username'], 'user1')
+        self.assertEqual(len(gathered[0]['keys']), 2)
+        self.assertEqual(gathered[1]['username'], 'user2')
+        self.assertEqual(len(gathered[1]['keys']), 0)


### PR DESCRIPTION
This PR adds the module user_authorized_keys which allows mangement of ssh keys per user, resolves #65.

- Based on PR #90
- Includes working example playbook with a valid key
- Includes module documentation and updates
- Includes unit tests for each supported state (gathered, merged, replaced, deleted)