### PR TITLE
Feature: config export and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ to communicate with Opengear devices via the REST API.
 | opengear.ng.auth                 | Manage remote authentication, authorization, and accounting (AAA) configuration.                     |
 | opengear.ng.conns                | Manage network connection configuration.                                                             |
 | opengear.ng.config_export        | Export current device configuration to file.                                                         |
+| opengear.ng.config_restore       | Restore device configuration from file.                                                              |
 | opengear.ng.facts                | Gather device information and network resource configuration facts.                                  |
 | opengear.ng.failover             | Manage failover configuration and retrieve failover status.                                          |
 | opengear.ng.firmware_upgrade     | Manage firmware upgrades on Opengear devices.                                                        |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ to communicate with Opengear devices via the REST API.
 | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | opengear.ng.auth                 | Manage remote authentication, authorization, and accounting (AAA) configuration.                     |
 | opengear.ng.conns                | Manage network connection configuration.                                                             |
+| opengear.ng.config_export        | Export current device configuration to file.                                                         |
 | opengear.ng.facts                | Gather device information and network resource configuration facts.                                  |
 | opengear.ng.failover             | Manage failover configuration and retrieve failover status.                                          |
 | opengear.ng.firmware_upgrade     | Manage firmware upgrades on Opengear devices.                                                        |

--- a/examples/playbooks/config_export.yaml
+++ b/examples/playbooks/config_export.yaml
@@ -1,0 +1,24 @@
+---
+# Export device configuration and save to file
+# The exported configuration is in dotnotation format and can be used
+# with the config_restore module to restore the configuration to a device.
+- name: Export Opengear device configuration
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    - name: Export device configuration
+      opengear.ng.config_export:
+        state: gathered
+      register: result
+
+    - name: Save configuration to file
+      ansible.builtin.copy:
+        content: "{{ result.gathered }}"
+        dest: "{{ backup_path }}/config-backup-{{ inventory_hostname }}.cfg"
+        mode: '0644'
+      delegate_to: localhost
+
+    - name: Show export summary
+      ansible.builtin.debug:
+        msg: "Configuration exported to {{ backup_path }}/config-backup-{{ inventory_hostname }}.cfg"

--- a/examples/playbooks/config_restore.yaml
+++ b/examples/playbooks/config_restore.yaml
@@ -1,0 +1,32 @@
+---
+# Restore device configuration from file.
+# The previously exported configuration file can be restored to the device using
+# the config_restore module. The version and SKU must match exactly.
+- name: Restore Opengear device configuration
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    - name: Restore device configuration
+      opengear.ng.config_restore:
+        config:
+          config_file: "{{ backup_path }}/config-backup-{{ inventory_hostname }}.cfg"
+        state: replaced
+      register: restore
+
+    - name: Wait for restore to complete
+      opengear.ng.config_restore:
+        state: gathered
+      register: status
+      until: status.gathered.restore.status != 'in_progress'
+      retries: 30
+      delay: 10
+      failed_when: false
+      when: restore.changed
+
+    - name: Assert restore succeeded
+      ansible.builtin.assert:
+        that:
+          - status.gathered.restore.status == 'completed'
+          - status.gathered.restore.exit_code == 0
+      when: restore.changed

--- a/plugins/httpapi/http_api.py
+++ b/plugins/httpapi/http_api.py
@@ -63,6 +63,24 @@ class HttpApi(HttpApiBase):
     def get(self, command, path, query_params):
         return self.send_request(data=command, path=path, query_params=query_params)
 
+    def get_raw(self, path, query_params=None):
+        """Fetch a raw response without JSON parsing.
+
+        Returns raw bytes, the caller decides how to handle them.
+        Use for text responses (decode as UTF-8) or binary responses
+        (keep as bytes or write directly to file).
+        """
+        headers = {'Content-Type': 'application/json'}
+        if query_params:
+            query_string = '&'.join(f'{k}={v}' for k, v in query_params.items())
+            path = f'{path}?{query_string}'
+        response, response_content = self.connection.send(
+            self.path + path, None, method='GET', headers=headers
+        )
+        if response_content:
+            return response_content.getvalue()
+        return None
+
     def send_request(self, data, path, method='GET', query_params=None):
         headers = {'Content-Type': 'application/json'}
         if query_params:

--- a/plugins/httpapi/http_api.py
+++ b/plugins/httpapi/http_api.py
@@ -33,7 +33,10 @@ def handle_response(response):
         try:
             handled_response = json.loads(content)
         except ValueError:
-            return {}
+            # Response is not JSON - return as text string.
+            # This handles unexpected plain text responses.
+            # For known binary or text responses use get_raw() instead.
+            return content.decode('utf-8', errors='replace')
         if "error" in handled_response:
             error = handled_response["error"][0]
             raise ConnectionError(error["text"], code=error["code"])

--- a/plugins/module_utils/argspec/config_export.py
+++ b/plugins/module_utils/argspec/config_export.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ConfigExportArgs(object):  # pylint: disable=R0903
+    """
+    Argument specification for the config_export module.
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    argument_spec = {
+        'state': {
+            'type': 'str',
+            'default': 'gathered',
+            'choices': [
+                'gathered',
+            ],
+        },
+    }  # pylint: disable=C0301

--- a/plugins/module_utils/argspec/config_restore.py
+++ b/plugins/module_utils/argspec/config_restore.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ConfigRestoreArgs(object):  # pylint: disable=R0903
+    """
+    Argument specification for the config_restore module.
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    argument_spec = {
+        'config': {
+            'type': 'dict',
+            'options': {
+                'config_file': {
+                    'type': 'str',
+                },
+            },
+        },
+        'state': {
+            'type': 'str',
+            'default': 'replaced',
+            'choices': [
+                'replaced',
+                'gathered',
+            ],
+        },
+    }  # pylint: disable=C0301

--- a/plugins/module_utils/config/config_export.py
+++ b/plugins/module_utils/config/config_export.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.plugins.module_utils.config.base import ConfigBase
+from ansible_collections.opengear.ng.plugins.module_utils.facts.config_export import ConfigExportFacts
+
+
+class ConfigExport(ConfigBase):
+    """
+    Retrieves device configuration export from Opengear devices.
+    """
+
+    gather_subset = ['!all', '!min']
+    gather_network_resources = ['config_export']
+
+    def __init__(self, module):
+        super(ConfigExport, self).__init__(module)
+
+    def get_config_export_facts(self):
+        """Get the current device configuration export.
+
+        :rtype: str
+        :returns: The device configuration in dotnotation format
+        """
+        ansible_facts = {'ansible_network_resources': {}}
+        # Use standalone facts for config export
+        instance = ConfigExportFacts(self._module)
+        instance.populate_facts(self._connection, ansible_facts)
+        return ansible_facts['ansible_network_resources'].get('config_export')
+
+    def execute_module(self):
+        """Execute the module.
+
+        :rtype: dict
+        :returns: The result from module execution
+        """
+        result = {'changed': False}
+        warnings = list()
+
+        result['gathered'] = self.get_config_export_facts()
+        result['warnings'] = warnings
+        return result

--- a/plugins/module_utils/config/config_restore.py
+++ b/plugins/module_utils/config/config_restore.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.plugins.module_utils.config.base import ConfigBase
+from ansible_collections.opengear.ng.plugins.module_utils.facts.config_restore import ConfigRestoreFacts
+
+
+class ConfigRestore(ConfigBase):
+    """
+    Manages configuration restore for Opengear devices.
+    """
+
+    gather_subset = ['!all', '!min']
+    gather_network_resources = ['config_restore']
+
+    def __init__(self, module):
+        super(ConfigRestore, self).__init__(module)
+
+    def get_config_restore_facts(self):
+        """Get the current restore status.
+
+        :rtype: dict
+        :returns: The current restore status
+        """
+        ansible_facts = {'ansible_network_resources': {}}
+        # Use standalone facts for config restore
+        instance = ConfigRestoreFacts(self._module)
+        instance.populate_facts(self._connection, ansible_facts)
+        return ansible_facts['ansible_network_resources'].get('config_restore')
+
+    def execute_module(self):
+        """Execute the module.
+
+        :rtype: dict
+        :returns: The result from module execution
+        """
+        result = {'changed': False}
+        warnings = list()
+
+        if self.state == 'gathered':
+            result['gathered'] = self.get_config_restore_facts()
+            result['warnings'] = warnings
+            return result
+
+        # replaced — initiate config restore
+        want = self._module.params['config']
+
+        if not want or not want.get('config_file'):
+            self._module.fail_json(msg="config_file is required for state: replaced")
+
+        if not self._module.check_mode:
+            self._connection.send_multipart_request(
+                'restore/config',
+                file_path=want['config_file'],
+            )
+        result['changed'] = True
+        result['warnings'] = warnings
+        return result

--- a/plugins/module_utils/facts/config_export.py
+++ b/plugins/module_utils/facts/config_export.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.config_export import ConfigExportArgs
+
+
+class ConfigExportFacts(object):
+    """
+    Retrieves device configuration export facts from Opengear devices.
+    """
+
+    def __init__(self, module):
+        self._module = module
+        self.argument_spec = ConfigExportArgs.argument_spec
+
+    def get_device_data(self, connection):
+        """Fetch the device configuration in dotnotation format."""
+        raw = connection.get_raw('export/config')
+        if raw:
+            if isinstance(raw, bytes):
+                return raw.decode('utf-8')
+            return raw
+        return None
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        """Populate the facts for config_export.
+
+        :param connection: the device connection
+        :param ansible_facts: Facts dictionary
+        :param data: previously collected conf
+        :rtype: dictionary
+        :returns: facts
+        """
+        if not data:
+            data = self.get_device_data(connection)
+
+        ansible_facts['ansible_network_resources'].pop('config_export', None)
+        facts = {}
+        if data:
+            facts['config_export'] = data
+
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/module_utils/facts/config_restore.py
+++ b/plugins/module_utils/facts/config_restore.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.config_restore import ConfigRestoreArgs
+
+
+class ConfigRestoreFacts(object):
+    """
+    Retrieves configuration restore status facts from Opengear devices.
+    """
+
+    def __init__(self, module):
+        self._module = module
+        self.argument_spec = ConfigRestoreArgs.argument_spec
+
+    def get_device_data(self, connection):
+        """Fetch the current restore status."""
+        return connection.get(None, 'restore/config')
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        """Populate the facts for config_restore.
+
+        :param connection: the device connection
+        :param ansible_facts: Facts dictionary
+        :param data: previously collected conf
+        :rtype: dictionary
+        :returns: facts
+        """
+        if not data:
+            data = self.get_device_data(connection)
+
+        ansible_facts['ansible_network_resources'].pop('config_restore', None)
+        facts = {}
+        if data:
+            facts['config_restore'] = data
+
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/modules/config_export.py
+++ b/plugins/modules/config_export.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: config_export
+version_added: '1.0.0'
+short_description: Export device configuration from Opengear devices
+description:
+  - Exports the current device configuration in dotnotation format.
+  - The exported configuration can be saved to a file and used with
+    the config_restore module to restore the configuration to a device.
+author:
+  - Opengear (@opengear)
+options:
+  state:
+    description:
+      - gathered - return the current device configuration in dotnotation format.
+    type: str
+    choices:
+      - gathered
+    default: gathered
+notes:
+  - The exported configuration is in dotnotation format, which is the native
+    configuration format for Opengear devices.
+  - The exported configuration can be edited before restoring, allowing
+    selective configuration changes to be applied.
+  - Use the config_restore module to apply the configuration back to a device.
+"""
+
+EXAMPLES = """
+- name: Export device configuration
+  opengear.ng.config_export:
+    state: gathered
+  register: result
+
+- name: Save configuration to file
+  ansible.builtin.copy:
+    content: "{{ result.gathered }}"
+    dest: "/path/to/config-backup.cfg"
+    mode: '0644'
+"""
+
+RETURN = """
+gathered:
+  description: The current device configuration in dotnotation format.
+  returned: always
+  type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.config_export import ConfigExportArgs
+from ansible_collections.opengear.ng.plugins.module_utils.config.config_export import ConfigExport
+
+
+def main():
+    """
+    Main entry point for module execution.
+
+    :returns: the result from module invocation
+    """
+    module = AnsibleModule(
+        argument_spec=ConfigExportArgs.argument_spec,
+        supports_check_mode=True,
+    )
+
+    result = ConfigExport(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/config_restore.py
+++ b/plugins/modules/config_restore.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: config_restore
+version_added: '1.0.0'
+short_description: Restore device configuration on Opengear devices
+description:
+  - Restores a previously exported device configuration from a dotnotation
+    format file.
+  - The configuration file must match the device version and SKU.
+  - Use the config_export module to export the current configuration.
+author:
+  - Opengear (@opengear)
+options:
+  config:
+    description: Configuration restore options.
+    type: dict
+    suboptions:
+      config_file:
+        type: str
+        description: >
+          Local path on the Ansible control node to the configuration file
+          in dotnotation format.
+  state:
+    description:
+      - replaced - initiate a configuration restore from the provided file.
+      - gathered - return the current restore operation status.
+    type: str
+    choices:
+      - replaced
+      - gathered
+    default: replaced
+notes:
+  - Performing a restore may cause the device to be temporarily unreachable.
+    Wait for the device to become available before running subsequent tasks.
+  - Use state=gathered to poll for restore completion status.
+  - The configuration file must have been exported from a device running
+    the same firmware version and SKU.
+"""
+
+EXAMPLES = """
+- name: Restore device configuration
+  opengear.ng.config_restore:
+    config:
+      config_file: "/path/to/config-backup.cfg"
+    state: replaced
+  register: restore
+
+- name: Wait for restore to complete
+  opengear.ng.config_restore:
+    state: gathered
+  register: status
+  until: status.gathered.status != 'in_progress'
+  retries: 30
+  delay: 10
+  failed_when: false
+  when: restore.changed
+
+- name: Assert restore succeeded
+  ansible.builtin.assert:
+    that:
+      - status.gathered.status == 'completed'
+      - status.gathered.exit_code == 0
+  when: restore.changed
+"""
+
+RETURN = """
+gathered:
+  description: The current restore operation status.
+  returned: when state is gathered
+  type: dict
+  contains:
+    status:
+      description: Current status of the restore operation.
+      type: str
+    restore_log:
+      description: Log output from the restore operation.
+      type: str
+    exit_code:
+      description: Exit code of the restore operation. 0 indicates success.
+      type: int
+    restore_status:
+      description: Detailed restore status identifier.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.opengear.ng.plugins.module_utils.argspec.config_restore import ConfigRestoreArgs
+from ansible_collections.opengear.ng.plugins.module_utils.config.config_restore import ConfigRestore
+
+
+def main():
+    """
+    Main entry point for module execution.
+
+    :returns: the result from module invocation
+    """
+    module = AnsibleModule(
+        argument_spec=ConfigRestoreArgs.argument_spec,
+        supports_check_mode=True,
+    )
+
+    result = ConfigRestore(module).execute_module()
+    for warning in result.pop('warnings', []):
+        module.warn(warning)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/modules/fixtures/config_export_config.cfg
+++ b/tests/unit/modules/fixtures/config_export_config.cfg
@@ -1,0 +1,25 @@
+VERSION="25.11.6"
+SKU="CM8148"
+config --secrets=obfuscate merge physifs <<'END'
+  physifs[0].description="1G Copper"
+  physifs[0].device="net1"
+  physifs[0].dns.nameservers=[]
+  physifs[0].dns.search_domains=[]
+  physifs[0].enabled=true
+  physifs[0].ethernet_setting.link_speed="auto"
+  physifs[0].media="ethernet"
+  physifs[0].mtu=1500
+  physifs[0].name="init_net1"
+  physifs[1].description="1G Copper"
+  physifs[1].device="net2"
+  physifs[1].dns.nameservers=[]
+  physifs[1].dns.search_domains=[]
+  physifs[1].enabled=true
+  physifs[1].ethernet_setting.link_speed="auto"
+  physifs[1].media="ethernet"
+  physifs[1].mtu=1500
+  physifs[1].name="init_net2"
+END
+config --secrets=obfuscate merge pdus <<'END'
+  pdus=[]
+END

--- a/tests/unit/modules/test_config_export.py
+++ b/tests/unit/modules/test_config_export.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import config_export
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase, load_fixture
+
+
+class TestConfigExportModule(TestModuleBase):
+
+    module = config_export
+
+    def setUp(self):
+        super(TestConfigExportModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_get_device_data = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.config_export.ConfigExportFacts.get_device_data"
+        )
+        self.get_device_data = self.mock_get_device_data.start()
+
+        self.mock_connection = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "config.base.Connection"
+        )
+        self.connection = self.mock_connection.start()
+
+    def tearDown(self):
+        super(TestConfigExportModule, self).tearDown()
+        self.mock_get_device_data.stop()
+        self.mock_connection.stop()
+
+    def load_fixtures(self, commands=None):
+        self.get_device_data.return_value = load_fixture("config_export_config.cfg")
+
+    # --- gathered ---
+    def test_config_export_gathered(self):
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        result = self.execute_module(changed=False)
+
+        self.assertIn('gathered', result)
+        self.assertIsNotNone(result['gathered'])
+        self.assertIsInstance(result['gathered'], str)
+        self.assertIn('VERSION="25.11.6"', result['gathered'])
+        self.assertIn('SKU="CM8148"', result['gathered'])
+        # config_export fixture contains physifs
+        self.assertIn('physifs', result['gathered'])
+        self.assertIn('physifs[0].device="net1"', result['gathered'])
+        self.assertIn('physifs[1].device="net2"', result['gathered'])
+
+    def test_config_export_not_changed(self):
+        """Config export is read-only and should never report changed"""
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        self.execute_module(changed=False)

--- a/tests/unit/modules/test_config_restore.py
+++ b/tests/unit/modules/test_config_restore.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import config_restore
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase
+
+
+class TestConfigRestoreModule(TestModuleBase):
+
+    module = config_restore
+
+    def setUp(self):
+        super(TestConfigRestoreModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_get_device_data = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "facts.config_restore.ConfigRestoreFacts.get_device_data"
+        )
+        self.get_device_data = self.mock_get_device_data.start()
+
+        self.mock_connection = patch(
+            "ansible_collections.opengear.ng.plugins.module_utils."
+            "config.base.Connection"
+        )
+        self.connection = self.mock_connection.start()
+
+    def tearDown(self):
+        super(TestConfigRestoreModule, self).tearDown()
+        self.mock_get_device_data.stop()
+        self.mock_connection.stop()
+
+    def load_fixtures(self, commands=None):
+        self.get_device_data.return_value = {
+            'restore': {
+                'status': 'completed',
+                'restore_log': 'VERSION check passed\nSKU check passed\nrunning restore\nrestore successful\n',
+                'exit_code': 0,
+                'restore_status': 'import_restore_complete',
+            }
+        }
+
+    # --- replaced ---
+    def test_config_restore_replaced(self):
+        set_module_args({
+            'config': {
+                'config_file': '/tmp/config-backup.cfg',
+            },
+            'state': 'replaced',
+        })
+
+        result = self.execute_module(changed=True)
+        self.connection.return_value.send_multipart_request.assert_called_once_with(
+            'restore/config',
+            file_path='/tmp/config-backup.cfg',
+        )
+
+    def test_config_restore_check_mode(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            'config': {
+                'config_file': '/tmp/config-backup.cfg',
+            },
+            'state': 'replaced',
+        })
+
+        result = self.execute_module(changed=True)
+        self.connection.return_value.send_multipart_request.assert_not_called()
+
+    def test_config_restore_missing_config_file(self):
+        set_module_args({
+            'config': {},
+            'state': 'replaced',
+        })
+
+        self.execute_module(failed=True)
+
+    def test_config_restore_missing_config(self):
+        set_module_args({
+            'state': 'replaced',
+        })
+
+        self.execute_module(failed=True)
+
+    # --- gathered ---
+    def test_config_restore_gathered_completed(self):
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        result = self.execute_module(changed=False)
+        self.assertIn('gathered', result)
+        self.assertEqual(result['gathered']['restore']['status'], 'completed')
+        self.assertEqual(result['gathered']['restore']['exit_code'], 0)
+        self.assertIn('restore successful', result['gathered']['restore']['restore_log'])
+
+    def test_config_restore_gathered_in_progress(self):
+        def load_in_progress(commands=None):
+            self.get_device_data.return_value = {
+                'restore': {
+                    'status': 'in_progress',
+                    'restore_log': '',
+                    'exit_code': None,
+                    'restore_status': 'system_ready',
+                }
+            }
+        self.load_fixtures = load_in_progress
+
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        result = self.execute_module(changed=False)
+        self.assertIn('gathered', result)
+        self.assertEqual(result['gathered']['restore']['status'], 'in_progress')
+        self.assertIsNone(result['gathered']['restore']['exit_code'])
+
+    def test_config_restore_not_changed_on_gathered(self):
+        set_module_args({
+            'state': 'gathered',
+        })
+
+        self.execute_module(changed=False)


### PR DESCRIPTION
This PR introduces config export (#86) and config restore (#87) with example playbook and unit tests.

Config export requires fetching the device configuration as raw bytes rather than a parsed JSON response. To support this, a `get_raw()` method has been added to the httpapi plugin that returns the response as bytes without JSON parsing, allowing the caller to decode it appropriately. The default request handler has also been updated to fall back to returning the response as a plain string when JSON parsing fails, rather than silently returning an empty dict.