### PR TITLE
Feature: config diff and config import

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,12 @@ The Opengear NG collection supports the following Opengear product families:
 - CM80xx
 - CM81xx
 
-## Connections
-Modules in this collection use the Ansible `httpapi` connection plugin by default
-to communicate with Opengear devices via the REST API.
-
 ## Modules
 | Name                             | Description                                                                                          |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | opengear.ng.auth                 | Manage remote authentication, authorization, and accounting (AAA) configuration.                     |
 | opengear.ng.conns                | Manage network connection configuration.                                                             |
+| opengear.ng.config_diff          | Compare current device configuration to file.                                                        |
 | opengear.ng.config_export        | Export current device configuration to file.                                                         |
 | opengear.ng.config_restore       | Restore device configuration from file.                                                              |
 | opengear.ng.facts                | Gather device information and network resource configuration facts.                                  |
@@ -37,6 +34,20 @@ to communicate with Opengear devices via the REST API.
 | opengear.ng.system               | Manage device system configuration and retrieve device information.                                  |
 | opengear.ng.user_authorized_keys | Manage configuration of user authorized keys on Opengear devices.                                    |
 | opengear.ng.users                | Manage user configuration.                                                                           |
+
+## Connections
+Modules in this collection use the Ansible `httpapi` connection plugin by default
+to communicate with Opengear devices via the REST API.
+
+The following modules are exceptions that require `ansible_connection: ssh` to
+be used and do not support the default `httpapi` connection.
+
+- [opengear.ng.config_diff][]
+
+See each module's documentation and examples for configuration and usage
+alongside httpapi modules.
+
+[opengear.ng.config_diff]: plugins/modules/config_diff.py
 
 ## Installing The Collection
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Opengear NG collection supports the following Opengear product families:
 | opengear.ng.conns                | Manage network connection configuration.                                                             |
 | opengear.ng.config_diff          | Compare current device configuration to file.                                                        |
 | opengear.ng.config_export        | Export current device configuration to file.                                                         |
+| opengear.ng.config_import        | Import device configuration from file merging with current device configuration.                     |
 | opengear.ng.config_restore       | Restore device configuration from file.                                                              |
 | opengear.ng.facts                | Gather device information and network resource configuration facts.                                  |
 | opengear.ng.failover             | Manage failover configuration and retrieve failover status.                                          |
@@ -43,11 +44,13 @@ The following modules are exceptions that require `ansible_connection: ssh` to
 be used and do not support the default `httpapi` connection.
 
 - [opengear.ng.config_diff][]
+- [opengear.ng.config_import][]
 
 See each module's documentation and examples for configuration and usage
 alongside httpapi modules.
 
 [opengear.ng.config_diff]: plugins/modules/config_diff.py
+[opengear.ng.config_import]: plugins/modules/config_import.py
 
 ## Installing The Collection
 

--- a/examples/playbooks/config_diff.yaml
+++ b/examples/playbooks/config_diff.yaml
@@ -1,0 +1,42 @@
+---
+# Generate a diff between configuration file and current device configuration
+# using the config_diff module via SSH connection.
+# The configuration file must be in dotnotation format from config_export.
+- name: Demonstrate config diff module
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    # Assume config_export performed, the config on the device has been modified
+    - name: Diff modified configuration against device
+      opengear.ng.config_diff:
+        config_content: "{{ lookup('file', backup_path + '/config-backup-' + inventory_hostname + '.cfg') }}"
+      vars:
+        ansible_connection: ssh
+      register: diff_result
+
+    - name: No differences found
+      ansible.builtin.debug:
+        msg: "Configuration matches device — no differences found."
+      when: not diff_result.changed
+
+    - name: Save diff to file
+      ansible.builtin.copy:
+        content: "{{ diff_result.diff.prepared }}"
+        dest: "{{ backup_path }}/config-diff-{{ inventory_hostname }}.txt"
+        mode: '0644'
+      delegate_to: localhost
+      when: diff_result.changed
+
+    - name: Show diff
+      ansible.builtin.command:
+        cmd: "cat {{ backup_path }}/config-diff-{{ inventory_hostname }}.txt"
+      delegate_to: localhost
+      when: diff_result.changed
+      register: cat_result
+      changed_when: false
+
+    - name: Print diff
+      ansible.builtin.debug:
+        msg: "{{ cat_result.stdout_lines }}"
+      when: diff_result.changed

--- a/examples/playbooks/config_import.yaml
+++ b/examples/playbooks/config_import.yaml
@@ -1,0 +1,25 @@
+---
+# Import device configuration from a previously exported file.
+#
+# Notes:
+# - The configuration file must be in dotnotation format (from config_export).
+# - The firmware version and SKU of the file must match the target device.
+# - If errors are encountered, the device will automatically roll back.
+# - For full configuration replacement, use config_restore instead.
+# - Use config_diff to preview changes before importing.
+- name: Demonstrate config import module
+  hosts: opengear
+  gather_facts: false
+
+  tasks:
+    # Assume config_export performed, the config will be imported and merged
+    - name: Import configuration
+      opengear.ng.config_import:
+        config_content: "{{ lookup('file', backup_path + '/config-backup-' + inventory_hostname + '.cfg') }}"
+      vars:
+        ansible_connection: ssh
+      register: import_result
+
+    - name: Show import result
+      ansible.builtin.debug:
+        var: import_result.msg

--- a/plugins/modules/config_diff.py
+++ b/plugins/modules/config_diff.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: config_diff
+version_added: '1.0.0'
+short_description: Diff device configuration on Opengear devices
+description:
+  - Compares the current device configuration against a provided configuration
+    and returns the differences in dotnotation format.
+  - The provided configuration content is written to a temporary file on the
+    device, compared using the C(config diff) command, and removed after comparison.
+author:
+  - Opengear (@opengear)
+options:
+  config_content:
+    description:
+      - The configuration content in dotnotation format to diff against the
+        current device configuration. Use the C(lookup) plugin or
+        C(config_export) module to obtain this content.
+    type: str
+    required: true
+  remote_tmp_dir:
+    description:
+      - Temporary directory on the device to store the config file during comparison.
+    type: str
+    default: /tmp
+notes:
+  - "This module requires `ansible_connection: ssh` to be set for the task or host. It cannot use the httpapi connection plugin."
+  - The user must have admin access on the device.
+  - C(changed) is true when differences are found between the current configuration and the provided content.
+  - Use the C(lookup) plugin to read a local file into C(config_content).
+"""
+
+EXAMPLES = """
+- name: Export current device configuration
+  opengear.ng.config_export:
+    state: gathered
+  register: export_result
+
+- name: Save configuration to file
+  ansible.builtin.copy:
+    content: "{{ export_result.gathered }}"
+    dest: "/tmp/device-config.cfg"
+    mode: '0644'
+  delegate_to: localhost
+
+# Make changes to /tmp/device-config.cfg here
+
+- name: Diff modified configuration against device
+  opengear.ng.config_diff:
+    config_content: "{{ lookup('file', '/tmp/device-config.cfg') }}"
+  vars:
+    ansible_connection: ssh
+  register: diff_result
+
+- name: No differences found
+  ansible.builtin.debug:
+    msg: "Configuration matches device — no differences found."
+  when: not diff_result.changed
+
+- name: Save diff to file
+  ansible.builtin.copy:
+    content: "{{ diff_result.diff.prepared }}"
+    dest: "/tmp/config-diff-result.txt"
+    mode: '0644'
+  delegate_to: localhost
+  when: diff_result.changed
+
+- name: Show diff
+  ansible.builtin.command:
+    cmd: "cat /tmp/config-diff-result.txt"
+  delegate_to: localhost
+  when: diff_result.changed
+  register: cat_result
+  changed_when: false
+
+- name: Print diff
+  ansible.builtin.debug:
+    msg: "{{ cat_result.stdout_lines }}"
+  when: diff_result.changed
+"""
+
+RETURN = """
+changed:
+  description: True if differences were found between the device configuration and the provided content.
+  returned: always
+  type: bool
+diff:
+  description: The differences between the current device configuration and the provided content.
+  returned: when changed
+  type: dict
+  contains:
+    prepared:
+      description: Diff output in dotnotation format.
+      type: str
+"""
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """
+    Main entry point for module execution.
+
+    :returns: the result from module invocation
+    """
+    argument_spec = {
+        'config_content': {
+            'type': 'str',
+            'required': True,
+            'no_log': False,
+        },
+        'remote_tmp_dir': {
+            'type': 'str',
+            'default': '/tmp',
+        },
+    }
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    config_content = module.params['config_content']
+    remote_tmp_dir = module.params['remote_tmp_dir']
+    remote_path = os.path.join(remote_tmp_dir, f"ansible_config_diff_{os.getpid()}.cfg")
+
+    result = {'changed': False}
+
+    try:
+        # Write config content to temp file on device
+        write_rc, write_stdout, write_stderr = module.run_command(
+            ['bash', '-c', f"cat > {remote_path}"],
+            data=config_content,
+        )
+        if write_rc != 0:
+            module.fail_json(
+                msg=f"Failed to write config content to device: {write_stderr}"
+            )
+
+        # Run config diff on the device
+        diff_rc, diff_stdout, diff_stderr = module.run_command(
+            ['config', 'diff', remote_path]
+        )
+
+        # exit code 1 means differences found, 0 means no differences
+        if diff_rc > 1:
+            module.fail_json(
+                msg=f"config diff failed: {diff_stderr}",
+                rc=diff_rc,
+            )
+
+        if diff_rc == 1:
+            result['changed'] = True
+            result['diff'] = {'prepared': diff_stdout}
+
+    finally:
+        # Always clean up the temp file
+        module.run_command(['rm', '-f', remote_path])
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/config_import.py
+++ b/plugins/modules/config_import.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: config_import
+version_added: '1.0.0'
+short_description: Import configuration on Opengear devices
+description:
+  - Merges a provided configuration into the current device configuration
+    using the C(config import) command.
+  - The provided configuration content is written to a temporary file on the
+    device, imported using C(config import), and removed after import.
+  - Use the C(config_diff) module to preview changes before importing.
+author:
+  - Opengear (@opengear)
+options:
+  config_content:
+    description:
+      - The configuration content in dotnotation format to import into the
+        device configuration. Use the C(lookup) plugin or C(config_export)
+        module to obtain this content.
+    type: str
+    required: true
+  remote_tmp_dir:
+    description:
+      - Temporary directory on the device to store the config file during import.
+    type: str
+    default: /tmp
+notes:
+  - This module requires C(ansible_connection) set to C(ssh) for the task
+    or host. It cannot use the httpapi connection plugin.
+  - The user must have admin access on the device.
+  - The configuration file must have been exported from a device running
+    the same firmware version and SKU. These values are checked at the
+    top of the export file.
+  - C(config import) merges configuration into the current device
+    configuration. If an error occurs, the device will automatically
+    roll back to the previous configuration. The error details are
+    returned in the module failure message.
+  - Use C(config_restore) for full configuration replacement instead of merge.
+  - Use C(config_diff) to preview changes before importing.
+"""
+
+EXAMPLES = """
+- name: Import configuration
+  opengear.ng.config_import:
+    config_content: "{{ lookup('file', config_backup_file) }}"
+  vars:
+    ansible_connection: ssh
+  register: import_result
+
+- name: Show import result
+  ansible.builtin.debug:
+    var: import_result.msg
+"""
+
+RETURN = """
+changed:
+  description: True if the configuration was imported successfully.
+  returned: always
+  type: bool
+msg:
+  description: Output from the config import command.
+  returned: always
+  type: str
+"""
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """
+    Main entry point for module execution.
+
+    :returns: the result from module invocation
+    """
+    argument_spec = {
+        'config_content': {
+            'type': 'str',
+            'required': True,
+            'no_log': False,
+        },
+        'remote_tmp_dir': {
+            'type': 'str',
+            'default': '/tmp',
+        },
+    }
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    config_content = module.params['config_content']
+    remote_tmp_dir = module.params['remote_tmp_dir']
+    remote_path = os.path.join(remote_tmp_dir, f"ansible_config_import_{os.getpid()}.cfg")
+
+    result = {'changed': False}
+
+    if module.check_mode:
+        result['changed'] = True
+        module.exit_json(**result)
+
+    try:
+        # Write config content to temp file on device
+        write_rc, write_stdout, write_stderr = module.run_command(
+            ['bash', '-c', f"cat > {remote_path}"],
+            data=config_content,
+        )
+        if write_rc != 0:
+            module.fail_json(
+                msg=f"Failed to write config content to device: {write_stderr}"
+            )
+
+        # Run config import on the device
+        import_rc, import_stdout, import_stderr = module.run_command(
+            ['config', 'import', remote_path]
+        )
+
+        if import_rc != 0:
+            module.fail_json(
+                msg=import_stderr.strip(),
+                rc=import_rc,
+            )
+
+        result['changed'] = True
+        result['msg'] = import_stdout.strip()
+
+    finally:
+        # Always clean up the temp file
+        module.run_command(['rm', '-f', remote_path])
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/modules/test_config_diff.py
+++ b/tests/unit/modules/test_config_diff.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import config_diff
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase
+
+DIFF_OUTPUT = (
+    "config --secrets=obfuscate merge physifs <<'END'\n"
+    "-  physifs[0].description=\"1G Copper\"\n"
+    "+  physifs[0].description=\"10G Copper\"\n"
+    "END\n"
+)
+
+CONFIG_CONTENT = (
+    "VERSION=\"25.11.6\"\n"
+    "SKU=\"CM8148\"\n"
+    "config --secrets=obfuscate merge physifs <<'END'\n"
+    "  physifs[0].description=\"10G Copper\"\n"
+    "END\n"
+)
+
+
+class TestConfigDiffModule(TestModuleBase):
+
+    module = config_diff
+
+    def setUp(self):
+        super(TestConfigDiffModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_run_command = patch(
+            'ansible.module_utils.basic.AnsibleModule.run_command'
+        )
+        self.run_command = self.mock_run_command.start()
+
+    def tearDown(self):
+        super(TestConfigDiffModule, self).tearDown()
+        self.mock_run_command.stop()
+
+    def load_fixtures(self, commands=None):
+        # Default: write succeeds, diff finds differences, cleanup succeeds
+        if not self.run_command.side_effect:    # only if not set by test
+            self.run_command.side_effect = [
+                (0, '', ''),                    # write succeeds
+                (1, DIFF_OUTPUT, ''),           # diff found
+                (0, '', ''),                    # cleanup
+            ]
+
+    # --- diff found ---
+    def test_config_diff_changed(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('diff', result)
+        self.assertIn('prepared', result['diff'])
+        self.assertEqual(result['diff']['prepared'], DIFF_OUTPUT)
+
+    def test_config_diff_changed_contains_diff_markers(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('-', result['diff']['prepared'])
+        self.assertIn('+', result['diff']['prepared'])
+
+    # --- no diff ---
+    def test_config_diff_no_changes(self):
+        self.run_command.side_effect = [
+            (0, '', ''),   # write succeeds
+            (0, '', ''),   # no diff
+            (0, '', ''),   # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=False)
+        self.assertNotIn('diff', result)
+
+    # --- write fails ---
+    def test_config_diff_write_fails(self):
+        self.run_command.side_effect = [
+            (1, '', 'permission denied'),  # write fails
+            (0, '', ''),                   # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(failed=True)
+
+    # --- diff command fails ---
+    def test_config_diff_command_fails(self):
+        self.run_command.side_effect = [
+            (0, '', ''),              # write succeeds
+            (2, '', 'syntax error'),  # diff command fails
+            (0, '', ''),              # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(failed=True)
+
+    # --- cleanup always runs ---
+    def test_config_diff_cleanup_runs_on_success(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(changed=True)
+        calls = self.run_command.call_args_list
+        cleanup_call = calls[-1]
+        self.assertIn('rm', cleanup_call[0][0])
+
+    def test_config_diff_cleanup_runs_on_failure(self):
+        self.run_command.side_effect = [
+            (0, '', ''),
+            (2, '', 'syntax error'),
+            (0, '', ''),
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(failed=True)
+        calls = self.run_command.call_args_list
+        cleanup_call = calls[-1]
+        self.assertIn('rm', cleanup_call[0][0])
+
+    # --- custom remote_tmp_dir ---
+    def test_config_diff_custom_tmp_dir(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+            'remote_tmp_dir': '/var/tmp',
+        })
+
+        self.execute_module(changed=True)
+        write_call = self.run_command.call_args_list[0]
+        self.assertIn('/var/tmp', str(write_call))

--- a/tests/unit/modules/test_config_import.py
+++ b/tests/unit/modules/test_config_import.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Opengear
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.opengear.ng.tests.unit.compat.mock import patch
+from ansible_collections.opengear.ng.plugins.modules import config_import
+from ansible_collections.opengear.ng.tests.unit.modules.utils import set_module_args
+from .module_test_base import TestModuleBase
+
+SUCCESS_OUTPUT = (
+    "VERSION check passed\n"
+    "SKU check passed\n"
+    "import successful"
+)
+
+SKU_ERROR = (
+    "import failed with the following error(s):\n"
+    "Error detected during IMPORT operation when attempting to validate "
+    "the contents. The SKU of the provided import file and the current "
+    "SKU of the system do not match. To proceed with an unsupported import "
+    "you may remove the 'SKU' line from the file and try again."
+)
+
+VALUE_ERROR = (
+    "import failed with the following error(s):\n"
+    "  Error:  Property 'power_alert_group.power_supply_voltage_alert.millivolt_lower'"
+    " is out of range 8000 to 16000\n"
+    "Type 'ogcli help monitoring/alerts/power' for examples specific to this entity."
+)
+
+CONFIG_CONTENT = (
+    "VERSION=\"25.11.6\"\n"
+    "SKU=\"CM8148\"\n"
+    "config --secrets=obfuscate merge physifs <<'END'\n"
+    "  physifs[0].description=\"1G Copper\"\n"
+    "END\n"
+)
+
+
+class TestConfigImportModule(TestModuleBase):
+
+    module = config_import
+
+    def setUp(self):
+        super(TestConfigImportModule, self).setUp()
+        self.maxDiff = None
+
+        self.mock_run_command = patch(
+            'ansible.module_utils.basic.AnsibleModule.run_command'
+        )
+        self.run_command = self.mock_run_command.start()
+
+    def tearDown(self):
+        super(TestConfigImportModule, self).tearDown()
+        self.mock_run_command.stop()
+
+    def load_fixtures(self, commands=None):
+        if not self.run_command.side_effect:
+            self.run_command.side_effect = [
+                (0, '', ''),              # write succeeds
+                (0, SUCCESS_OUTPUT, ''),  # import succeeds
+                (0, '', ''),              # cleanup
+            ]
+
+    # --- import succeeds ---
+    def test_config_import_success(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('msg', result)
+        self.assertIn('import successful', result['msg'])
+
+    def test_config_import_success_msg_contains_checks(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=True)
+        self.assertIn('VERSION check passed', result['msg'])
+        self.assertIn('SKU check passed', result['msg'])
+
+    # --- check mode ---
+    def test_config_import_check_mode(self):
+        set_module_args({
+            '_ansible_check_mode': True,
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(changed=True)
+        self.run_command.assert_not_called()
+
+    # --- write fails ---
+    def test_config_import_write_fails(self):
+        self.run_command.side_effect = [
+            (1, '', 'permission denied'),  # write fails
+            (0, '', ''),                   # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(failed=True)
+
+    # --- import fails ---
+    def test_config_import_sku_mismatch(self):
+        self.run_command.side_effect = [
+            (0, '', ''),           # write succeeds
+            (1, '', SKU_ERROR),    # import fails - sku mismatch
+            (0, '', ''),           # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(failed=True)
+        self.assertIn('SKU', result['msg'])
+
+    def test_config_import_value_error(self):
+        self.run_command.side_effect = [
+            (0, '', ''),            # write succeeds
+            (1, '', VALUE_ERROR),   # import fails - value out of range
+            (0, '', ''),            # cleanup
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        result = self.execute_module(failed=True)
+        self.assertIn('out of range', result['msg'])
+
+    # --- cleanup always runs ---
+    def test_config_import_cleanup_runs_on_success(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(changed=True)
+        calls = self.run_command.call_args_list
+        cleanup_call = calls[-1]
+        self.assertIn('rm', cleanup_call[0][0])
+
+    def test_config_import_cleanup_runs_on_failure(self):
+        self.run_command.side_effect = [
+            (0, '', ''),
+            (1, '', SKU_ERROR),
+            (0, '', ''),
+        ]
+
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+        })
+
+        self.execute_module(failed=True)
+        calls = self.run_command.call_args_list
+        cleanup_call = calls[-1]
+        self.assertIn('rm', cleanup_call[0][0])
+
+    # --- custom remote_tmp_dir ---
+    def test_config_import_custom_tmp_dir(self):
+        set_module_args({
+            'config_content': CONFIG_CONTENT,
+            'remote_tmp_dir': '/var/tmp',
+        })
+
+        self.execute_module(changed=True)
+        write_call = self.run_command.call_args_list[0]
+        self.assertIn('/var/tmp', str(write_call))


### PR DESCRIPTION
This PR introduces config diff (#96) and config import (#97)  with example playbook and unit tests.

These modules are a little different in that they do not support the httpapi connection and require the use of `ansible_connection: ssh`, as there is no REST API for these features on the Opengear device spec at this time. The approach for SSH modules basically wraps existing ansible commands and does not use the same structure of internal module_utils with argspec, config and facts. The README  documentation and example playbooks are updated to call this out explicitly and demonstrate how they should be used.